### PR TITLE
Beginnings of stubbing out serialization patterns

### DIFF
--- a/assessmentModel/src/androidLibTest/kotlin/serialization/ImageTestJavaHelper.kt
+++ b/assessmentModel/src/androidLibTest/kotlin/serialization/ImageTestJavaHelper.kt
@@ -1,0 +1,11 @@
+package org.sagebionetworks.assessmentmodel.serialization
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.sagebionetworks.assessmentmodel.serialization.ImageTest
+import kotlin.test.Ignore
+
+// special class for running test within IDE
+@RunWith(JUnit4::class)
+class ImageTestJavaHelper : ImageTest()
+

--- a/assessmentModel/src/commonMain/kotlin/Assessment.kt
+++ b/assessmentModel/src/commonMain/kotlin/Assessment.kt
@@ -88,12 +88,12 @@ interface Node : ResultMapElement {
      * List of button actions that should be hidden for this node even if the node subtype typically supports displaying
      * the button on screen.
      */
-    val hideButtons: List<ButtonAction>
+    val hideButtons: List<ButtonActionType>
 
     /**
-     * A mapping of a [ButtonAction] to a [Button].
+     * A mapping of a [ButtonActionType.name] to a [Button].
      */
-    val buttonMap: Map<ButtonAction, Button>
+    val buttonMap: Map<String, Button>
 }
 
 /**

--- a/assessmentModel/src/commonMain/kotlin/ImageInfo.kt
+++ b/assessmentModel/src/commonMain/kotlin/ImageInfo.kt
@@ -1,20 +1,23 @@
 package org.sagebionetworks.assessmentmodel
 
+import kotlinx.serialization.*
+import kotlinx.serialization.internal.StringDescriptor
+import org.sagebionetworks.assessmentmodel.serialization.ExtendableStringEnum
+import org.sagebionetworks.assessmentmodel.serialization.ExtendableStringEnumSerializer
+import org.sagebionetworks.assessmentmodel.serialization.StringEnum
+import org.sagebionetworks.assessmentmodel.serialization.matching
+
 /**
  * The [ImageInfo] is used to define a placeholder for an image. This could refer to a drawable object as defined by
- * the platform, a url, or the name of an embedded resource. The [height] and [width], if defined, describe the image
- * size and can be defined in either pixels or points. The [imageIdentifier] is used to uniquely identify this image
- * (or set of images) so that the client platform can fetch the image data. The [label] may be displayed as a caption
- * for the image or set as the accessibility label for the image on platforms that implement user accessibility on
- * images.
+ * the platform, a url, or the name of an embedded resource.
  */
 interface ImageInfo {
 
     /**
      * A unique identifier that can be used to validate that the image shown in a reusable view is the same image as the
-     * one fetched.
+     * one fetched. This can also be used as the string value to fetch an image.
      */
-    val imageIdentifier: String
+    val imageName: String
 
     /**
      * A caption or label to display for the image in a localized string.
@@ -22,24 +25,112 @@ interface ImageInfo {
     val label: String?
 
     /**
-     * The preferred placement of the image.
+     * The preferred placement of the image. If undefined, then the default placement will depend upon the UI view being
+     * used to display the image.
      */
-    val placement: ImagePlacement
-        get() = ImagePlacement.iconBefore
+    val imagePlacement: ImagePlacementType?
 
     /**
-     * The height of the image.
+     * The size of the image in whatever units are appropriate for the given platform.
      */
-    val height: Int
-        get() = 0
+    val imageSize: Size?
+}
+
+interface AnimatedImageInfo : ImageInfo {
 
     /**
-     * The width of the image.
+     * The list of image names for the images to include in this animation.
      */
-    val width: Int
-        get() = 0
+    val animationImageNames: List<String>
+
+    /**
+     * The animation duration for the image animation.
+     */
+    val animationDuration: Double
+
+    /**
+     * This is used to set how many times the animation should be repeated where `0` means infinite.
+     */
+    val animationRepeatCount: Int?
 }
 
-enum class ImagePlacement {
-    iconBefore, iconAfter, fullsizeBackground, topBackground, topMarginBackground
+/**
+ * An interface that is used to wrap the [name] keyword and allow for an extendable string enum used to give a hint to
+ * an [Assessment] developer of the layout to use for a given image. Typically, this is included so that a developer can
+ * reuse the same view class where the designer requires different layout constraints for the image depending upon what
+ * the image is showing.
+ *
+ * For example,
+ * - An image of a person's midsection will look strange if the image does not "cut off" at the edges of the screen so
+ * should be constrained to the edges. This is described using [ImagePlacement.Standard.TopBackground].
+ * - An image of a person standing should be constrained to below the phone status bar so that the person is not
+ * decapitated. This is described using [ImagePlacement.Standard.TopMarginBackground].
+ * - An image of a trophy or smiley face should fit the screen real-estate with a size constraint and margins. This is
+ * described using [ImagePlacement.Standard.IconBefore] or [ImagePlacement.Standard.IconAfter].
+ *
+ */
+interface ImagePlacementType : StringEnum
+
+@Serializer(forClass = ImagePlacementType::class)
+object ImagePlacementTypeSerializer: ExtendableStringEnumSerializer<ImagePlacementType>("ImagePlacementType", ImagePlacement)
+
+/**
+ * String wrapper for describing the image placement of an image. This is used to allow extending the
+ * [ImagePlacement.Standard] enum to allow for custom placement typing.
+ */
+object ImagePlacement : ExtendableStringEnum <ImagePlacementType> {
+
+    /**
+     * This class defines a set of image placements that are defined within this framework as standard.
+     * For all placements that use `background`, the image should use `aspect fill`. For all `icon` placements, the
+     * image should use `aspect fit`.
+     *
+     * - [IconBefore]:
+     *      Display the image "before" the content. For a portrait orientation, this would indicate that the image should
+     *      be displayed *above* the content. For landscape orientation, this would indicate that for languages that read
+     *      left to right, the image should be on the *left*.
+     * - [IconAfter]:
+     *      Display the image "after" the content. For portrait orientation, this would be *below* the content. For
+     *      landscape orientation for languages that read left to right, the image should be on the *right*.
+     * - [FullSizeBackground]:
+     *      Display the image full size in the background of the view.
+     * - [TopBackground]:
+     *      Top half of the background constrained to the top of the screen rather than to the safe area. On platforms that
+     *      support drawing the image under the status bar and in the area of the "notch", this would draw in that area.
+     * - [TopMarginBackground]:
+     *      Top half of the background constrained to the safe area.
+     * - [BackgroundBefore]:
+     *      Display the image "before" the content in the background. In portrait, this is equivalent to
+     *      [TopBackground] and in landscape for languages that read left to right, this would be the *left*
+     *      half of the view.
+     * - [BackgroundAfter]:
+     *      Display the image "after" the content in the background. In portrait, the image should display using
+     *      [TopBackground], but in landscape for languages that read left to right, this would display on the *right*
+     *      half of the view.
+     */
+    @Serializable
+    enum class Standard : ImagePlacementType {
+        IconBefore,
+        IconAfter,
+        FullSizeBackground,
+        TopBackground,
+        TopMarginBackground,
+        BackgroundBefore,
+        BackgroundAfter,
+        ;
+    }
+
+    @Serializable(with = ImagePlacementTypeSerializer::class)
+    data class Custom(override val name: String) : ImagePlacementType
+
+    override fun standardValues(): Array<ImagePlacementType> {
+        return Standard.values() as Array<ImagePlacementType>
+    }
+
+    override fun custom(name: String): ImagePlacementType {
+        return Custom(name)
+    }
 }
+
+@Serializable
+data class Size(val width: Int = 0, val height: Int = 0)

--- a/assessmentModel/src/commonMain/kotlin/Result.kt
+++ b/assessmentModel/src/commonMain/kotlin/Result.kt
@@ -26,13 +26,13 @@ interface CollectionResult : Result {
      * [Assessment]. This will only include a subset that is the path defined at this level of the overall [Assessment]
      * hierarchy.
      */
-    var pathResults: List<Result>
+    var pathResults: MutableList<Result>
 
     /**
      * The [asyncActionResults] is a set that contains results that are recorded in parallel to the user-facing node
      * path.
      */
-    var asyncActionResults: Set<Result>?
+    var asyncActionResults: MutableSet<Result>
 }
 
 /**

--- a/assessmentModel/src/commonMain/kotlin/serialization/ExtendableStringEnum.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/ExtendableStringEnum.kt
@@ -1,0 +1,36 @@
+package org.sagebionetworks.assessmentmodel.serialization
+
+import kotlinx.serialization.*
+import kotlinx.serialization.internal.StringDescriptor
+
+interface StringEnum {
+    val name: String
+}
+
+fun <T> Array<T>.matching(name: String) where T : StringEnum =
+        this.firstOrNull { it.name.toLowerCase() == name.toLowerCase() }
+
+interface ExtendableStringEnum<T : StringEnum> {
+    fun standardValues(): Array<T>
+    fun custom(name: String): T
+
+    fun valueOf(name: String): T =
+            standardValues().matching(name) ?: custom(name)
+}
+
+open class ExtendableStringEnumSerializer<T : StringEnum>(
+        serialName: String,
+        val stringEnum: ExtendableStringEnum<T>)
+    : KSerializer<T> {
+
+    override val descriptor: SerialDescriptor
+            = StringDescriptor.withName(serialName)
+
+    override fun serialize(encoder: Encoder, obj: T) {
+        encoder.encodeString(obj.name)
+    }
+
+    override fun deserialize(decoder: Decoder): T {
+        return stringEnum.valueOf(decoder.decodeString())
+    }
+}

--- a/assessmentModel/src/commonMain/kotlin/serialization/Image.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/Image.kt
@@ -1,0 +1,50 @@
+package org.sagebionetworks.assessmentmodel.serialization
+
+import kotlinx.serialization.*
+import kotlinx.serialization.internal.StringDescriptor
+import kotlinx.serialization.modules.SerializersModule
+import org.sagebionetworks.assessmentmodel.*
+
+// TODO: syoung 01/13/2020 Figure out how to carry the resource bundle as a part of decoding an image and/or how to load an image from a Kotlin resource directory.
+
+val imageSerializersModule = SerializersModule {
+    polymorphic(ImageInfo::class) {
+        FetchableImage::class with FetchableImage.serializer()
+        AnimatedImage::class with AnimatedImage.serializer()
+    }
+}
+
+@Serializable
+@SerialName("fetchable")
+data class FetchableImage(override val imageName: String,
+                          override val label: String? = null,
+                          @SerialName("placementType")
+                          @Serializable(with=ImagePlacementTypeSerializer::class)
+                          override val imagePlacement: ImagePlacementType? = null,
+                          override val imageSize: Size? = null) : ImageInfo
+
+@Serializable
+@SerialName("animated")
+data class AnimatedImage(override val animationImageNames: List<String>,
+                         override val animationDuration: Double,
+                         override val animationRepeatCount: Int?,
+                         override val label: String? = null,
+                         @SerialName("placementType")
+                         @Serializable(with=ImagePlacementTypeSerializer::class)
+                         override val imagePlacement: ImagePlacementType? = null,
+                         override val imageSize: Size? = null) : AnimatedImageInfo {
+    override val imageName: String
+        get() = animationImageNames.first()
+}
+
+@Serializer(forClass = FetchableImage::class)
+object ImageNameSerializer : KSerializer<FetchableImage> {
+    override val descriptor: SerialDescriptor
+            = StringDescriptor.withName("ImageName")
+    override fun deserialize(decoder: Decoder): FetchableImage {
+        return FetchableImage(decoder.decodeString())
+    }
+    override fun serialize(encoder: Encoder, obj: FetchableImage) {
+        encoder.encodeString(obj.imageName)
+    }
+}

--- a/assessmentModel/src/commonMain/kotlin/serialization/Nodes.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/Nodes.kt
@@ -1,0 +1,38 @@
+package org.sagebionetworks.assessmentmodel.serialization
+
+import kotlinx.serialization.Polymorphic
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonConfiguration
+import kotlinx.serialization.list
+import kotlinx.serialization.modules.SerializersModule
+import org.sagebionetworks.assessmentmodel.*
+
+@Serializable
+@SerialName("section")
+data class SectionObject(override val identifier: String,
+                         override val resultIdentifier: String? = null,
+                         @Polymorphic
+                         @SerialName("steps")
+                         override val children: List<Node>,
+                         override val comment: String? = null,
+                         override val title: String? = null,
+                         override val label: String? = null,
+                         @SerialName("icon")
+                         @Serializable(with=ImageNameSerializer::class)
+                         override val imageInfo: FetchableImage? = null,
+                         override val detail: String? = null,
+                         @SerialName("shouldHideActions")
+                         @Serializable(with=ButtonActionTypeSerializer::class)
+                         override val hideButtons: List<ButtonActionType> = listOf(),
+                         @Polymorphic
+                         @SerialName("actions")
+                         override val buttonMap: Map<String, Button> = mapOf(),
+                         @Polymorphic
+                         @SerialName("asyncActions")
+                         override val backgroundActions: List<AsyncActionConfiguration> = listOf()) : Section, AsyncActionContainer {
+    override fun createResult(): Result {
+        return CollectionResultObject(identifier = identifier)
+    }
+}

--- a/assessmentModel/src/commonMain/kotlin/serialization/Results.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/Results.kt
@@ -1,0 +1,6 @@
+package org.sagebionetworks.assessmentmodel.serialization
+
+import org.sagebionetworks.assessmentmodel.CollectionResult
+import org.sagebionetworks.assessmentmodel.Result
+
+data class CollectionResultObject(override val identifier: String, override var pathResults: MutableList<Result> = mutableListOf(), override var asyncActionResults: MutableSet<Result> = mutableSetOf()) : CollectionResult

--- a/assessmentModel/src/commonTest/kotlin/serialization/ImageTest.kt
+++ b/assessmentModel/src/commonTest/kotlin/serialization/ImageTest.kt
@@ -1,0 +1,46 @@
+package org.sagebionetworks.assessmentmodel.serialization
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import org.sagebionetworks.assessmentmodel.ImageInfo
+import org.sagebionetworks.assessmentmodel.ImagePlacement
+import org.sagebionetworks.assessmentmodel.Size
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@Serializable
+data class TestImageWrapper(val image: ImageInfo)
+
+val jsonCoder = Json(context = imageSerializersModule)
+
+open class ImageTest {
+
+    @Test
+    fun testFetchableImageWithDefaults() {
+        val image = FetchableImage("before")
+        val inputString = """{"image":{"type":"fetchable","imageName":"before"}}"""
+
+        val original = TestImageWrapper(image)
+        val jsonString = jsonCoder.stringify(TestImageWrapper.serializer(), original)
+        assertEquals(inputString, jsonString)
+        val restored = jsonCoder.parse(TestImageWrapper.serializer(), inputString)
+        assertEquals(original, restored)
+
+        println("PASSED testFetchableImageWithDefaults")
+    }
+
+    @Test
+    fun testFetchableImageWithValues() {
+        val image = FetchableImage("before", imagePlacement = ImagePlacement.Standard.BackgroundBefore, label = "Foo", imageSize = Size(width = 20, height = 40))
+        val inputString = """{"image":{"type":"fetchable","imageName":"before","label":"Foo","placementType":"BackgroundBefore","imageSize":{"width":20,"height":40}}}"""
+
+        val original = TestImageWrapper(image)
+        val jsonString = jsonCoder.stringify(TestImageWrapper.serializer(), original)
+        assertEquals(inputString, jsonString)
+        val restored = jsonCoder.parse(TestImageWrapper.serializer(), inputString)
+        assertEquals(original, restored)
+
+        println("PASSED testFetchableImageWithValues")
+    }
+}


### PR DESCRIPTION
I updated the documentation for the image placement type and the button type.

Most of this PR is working out a way to define "extendable string enums", which is something that we use extensively on iOS. The basic concept is a that the enum is backed by a string, includes a set of "standard" subtypes that are included in the base framework, but can be extended to include custom keys that are understood by the application that is using them.

For example, `ButtonActionType` is used to map a button model (image, localized text) to a UIButton. There are a set of standard buttons that may or may not be applicable for a given view dealing with navigation. But this may also be used to define custom buttons such as "Add medication" or "Delete" so it needs to be extendable.

I looked into *not* using an enum for this and instead using a data class with some default values defined on the companion object, but serialization became a nightmare.  Additionally, convention in Java, Kotlin, and Swift for case-sensitive strings is different and I wanted to avoid incorrect deserialization b/c of this. There is still a fair amount of boilerplate, but I think it will be less brittle than the other serialization methods that I looked into.

Note 1: Unit tests aren't passing right now. I can't get them to run consistently and in addition, serialization includes `null` values for `testFetchableImageWithDefaults()` which according to the documentation, it shouldn't. I found this https://github.com/Kotlin/kotlinx.serialization/issues/442 but couldn't figure out how to apply that solution to the Gradle. :(

Note 2: I couldn't get the iOS app to build and thus, couldn't look at the header files.