### PR TITLE
Added comments and changed the implementation of the image info

### DIFF
--- a/assessmentModel/src/commonMain/kotlin/ImageInfo.kt
+++ b/assessmentModel/src/commonMain/kotlin/ImageInfo.kt
@@ -11,7 +11,7 @@ import org.sagebionetworks.assessmentmodel.serialization.matching
  * The [ImageInfo] is used to define a placeholder for an image. This could refer to a drawable object as defined by
  * the platform, a url, or the name of an embedded resource.
  */
-interface ImageInfo {
+interface ImageInfo : DrawableLayout {
 
     /**
      * A unique identifier that can be used to validate that the image shown in a reusable view is the same image as the
@@ -23,17 +23,6 @@ interface ImageInfo {
      * A caption or label to display for the image in a localized string.
      */
     val label: String?
-
-    /**
-     * The preferred placement of the image. If undefined, then the default placement will depend upon the UI view being
-     * used to display the image.
-     */
-    val imagePlacement: ImagePlacementType?
-
-    /**
-     * The size of the image in whatever units are appropriate for the given platform.
-     */
-    val imageSize: Size?
 }
 
 interface AnimatedImageInfo : ImageInfo {
@@ -55,82 +44,9 @@ interface AnimatedImageInfo : ImageInfo {
 }
 
 /**
- * An interface that is used to wrap the [name] keyword and allow for an extendable string enum used to give a hint to
- * an [Assessment] developer of the layout to use for a given image. Typically, this is included so that a developer can
- * reuse the same view class where the designer requires different layout constraints for the image depending upon what
- * the image is showing.
- *
- * For example,
- * - An image of a person's midsection will look strange if the image does not "cut off" at the edges of the screen so
- * should be constrained to the edges. This is described using [ImagePlacement.Standard.TopBackground].
- * - An image of a person standing should be constrained to below the phone status bar so that the person is not
- * decapitated. This is described using [ImagePlacement.Standard.TopMarginBackground].
- * - An image of a trophy or smiley face should fit the screen real-estate with a size constraint and margins. This is
- * described using [ImagePlacement.Standard.IconBefore] or [ImagePlacement.Standard.IconAfter].
- *
- */
-interface ImagePlacementType : StringEnum
-
-@Serializer(forClass = ImagePlacementType::class)
-object ImagePlacementTypeSerializer: ExtendableStringEnumSerializer<ImagePlacementType>("ImagePlacementType", ImagePlacement)
-
-/**
- * String wrapper for describing the image placement of an image. This is used to allow extending the
- * [ImagePlacement.Standard] enum to allow for custom placement typing.
- */
-object ImagePlacement : ExtendableStringEnum <ImagePlacementType> {
-
-    /**
-     * This class defines a set of image placements that are defined within this framework as standard.
-     * For all placements that use `background`, the image should use `aspect fill`. For all `icon` placements, the
-     * image should use `aspect fit`.
-     *
-     * - [IconBefore]:
-     *      Display the image "before" the content. For a portrait orientation, this would indicate that the image should
-     *      be displayed *above* the content. For landscape orientation, this would indicate that for languages that read
-     *      left to right, the image should be on the *left*.
-     * - [IconAfter]:
-     *      Display the image "after" the content. For portrait orientation, this would be *below* the content. For
-     *      landscape orientation for languages that read left to right, the image should be on the *right*.
-     * - [FullSizeBackground]:
-     *      Display the image full size in the background of the view.
-     * - [TopBackground]:
-     *      Top half of the background constrained to the top of the screen rather than to the safe area. On platforms that
-     *      support drawing the image under the status bar and in the area of the "notch", this would draw in that area.
-     * - [TopMarginBackground]:
-     *      Top half of the background constrained to the safe area.
-     * - [BackgroundBefore]:
-     *      Display the image "before" the content in the background. In portrait, this is equivalent to
-     *      [TopBackground] and in landscape for languages that read left to right, this would be the *left*
-     *      half of the view.
-     * - [BackgroundAfter]:
-     *      Display the image "after" the content in the background. In portrait, the image should display using
-     *      [TopBackground], but in landscape for languages that read left to right, this would display on the *right*
-     *      half of the view.
-     */
-    @Serializable
-    enum class Standard : ImagePlacementType {
-        IconBefore,
-        IconAfter,
-        FullSizeBackground,
-        TopBackground,
-        TopMarginBackground,
-        BackgroundBefore,
-        BackgroundAfter,
-        ;
-    }
-
-    @Serializable(with = ImagePlacementTypeSerializer::class)
-    data class Custom(override val name: String) : ImagePlacementType
-
-    override fun standardValues(): Array<ImagePlacementType> {
-        return Standard.values() as Array<ImagePlacementType>
-    }
-
-    override fun custom(name: String): ImagePlacementType {
-        return Custom(name)
-    }
-}
-
-@Serializable
-data class Size(val width: Int = 0, val height: Int = 0)
+ * The frame layout is a generic interface that can be extended to include descriptive layout for the drawable element
+ * with which it is associated.  This may include size, placement hints, alignment, or other more complex descriptions
+ * for the constraints that the image view should apply when rendering the image. This interface is intentionally
+ * generic since each platform may model this differently in a manner that is logical for the given platform.
+*/
+interface DrawableLayout

--- a/assessmentModel/src/commonMain/kotlin/Result.kt
+++ b/assessmentModel/src/commonMain/kotlin/Result.kt
@@ -22,11 +22,11 @@ interface Result {
 interface CollectionResult : Result {
 
     /**
-     * The [pathResults] includes the history of the [Node] results that were traversed as a part of running an
+     * The [pathHistoryResults] includes the history of the [Node] results that were traversed as a part of running an
      * [Assessment]. This will only include a subset that is the path defined at this level of the overall [Assessment]
      * hierarchy.
      */
-    var pathResults: MutableList<Result>
+    var pathHistoryResults: MutableList<Result>
 
     /**
      * The [asyncActionResults] is a set that contains results that are recorded in parallel to the user-facing node

--- a/assessmentModel/src/commonMain/kotlin/serialization/ExtendableStringEnum.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/ExtendableStringEnum.kt
@@ -3,13 +3,24 @@ package org.sagebionetworks.assessmentmodel.serialization
 import kotlinx.serialization.*
 import kotlinx.serialization.internal.StringDescriptor
 
+/**
+ * A string enum is an enum that uses a string as its raw value.
+ */
 interface StringEnum {
     val name: String
 }
 
+/**
+ * This framework considers string enums to be case insensitive. This is to allow for different languages to support
+ * different conventions.
+ */
 fun <T> Array<T>.matching(name: String) where T : StringEnum =
         this.firstOrNull { it.name.toLowerCase() == name.toLowerCase() }
 
+/**
+ * An extendable string enum defines an interface for extending a string enum to include an array of [standardValues]
+ * and also allow for [custom] string extensions.
+ */
 interface ExtendableStringEnum<T : StringEnum> {
     fun standardValues(): Array<T>
     fun custom(name: String): T

--- a/assessmentModel/src/commonMain/kotlin/serialization/Image.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/Image.kt
@@ -20,8 +20,8 @@ data class FetchableImage(override val imageName: String,
                           override val label: String? = null,
                           @SerialName("placementType")
                           @Serializable(with=ImagePlacementTypeSerializer::class)
-                          override val imagePlacement: ImagePlacementType? = null,
-                          override val imageSize: Size? = null) : ImageInfo
+                          override val imagePlacementType: ImagePlacementType? = null,
+                          override val size: Size? = null) : ImageInfo, ImageTheme
 
 @Serializable
 @SerialName("animated")
@@ -31,10 +31,19 @@ data class AnimatedImage(override val animationImageNames: List<String>,
                          override val label: String? = null,
                          @SerialName("placementType")
                          @Serializable(with=ImagePlacementTypeSerializer::class)
-                         override val imagePlacement: ImagePlacementType? = null,
-                         override val imageSize: Size? = null) : AnimatedImageInfo {
+                         override val imagePlacementType: ImagePlacementType,
+                         override val size: Size? = null) : AnimatedImageInfo, ImageTheme {
     override val imageName: String
         get() = animationImageNames.first()
+}
+
+/**
+ * [ImageTheme] is a [FrameLayout] that was developed for SageResearch-Apple and uses a serialization strategy where
+ * layout is defined by the image placement and size (where applicable) rather than using specific image constraints.
+ */
+interface ImageTheme : DrawableLayout {
+    val imagePlacementType: ImagePlacementType?
+    val size: Size?
 }
 
 @Serializer(forClass = FetchableImage::class)
@@ -48,3 +57,89 @@ object ImageNameSerializer : KSerializer<FetchableImage> {
         encoder.encodeString(obj.imageName)
     }
 }
+
+/**
+ * An interface that is used to wrap the [name] keyword and allow for an extendable string enum used to give a hint to
+ * an [Assessment] developer of the layout to use for a given image. Typically, this is included so that a developer can
+ * reuse the same view class where the designer requires different layout constraints for the image depending upon what
+ * the image is showing.
+ *
+ * For example,
+ * - An image of a person's midsection will look strange if the image does not "cut off" at the edges of the screen so
+ * should be constrained to the edges. This is described using [ImagePlacement.Standard.TopBackground].
+ * - An image of a person standing should be constrained to below the phone status bar so that the person is not
+ * decapitated. This is described using [ImagePlacement.Standard.TopMarginBackground].
+ * - An image of a trophy or smiley face should fit the screen real-estate with a size constraint and margins. This is
+ * described using [ImagePlacement.Standard.IconBefore] or [ImagePlacement.Standard.IconAfter].
+ *
+ */
+interface ImagePlacementType : StringEnum
+
+@Serializer(forClass = ImagePlacementType::class)
+object ImagePlacementTypeSerializer:
+        ExtendableStringEnumSerializer<ImagePlacementType>("ImagePlacementType", ImagePlacement)
+
+/**
+ * String wrapper for describing the image placement of an image. This is used to allow extending the
+ * [ImagePlacement.Standard] enum to allow for custom placement typing.
+ */
+object ImagePlacement : ExtendableStringEnum <ImagePlacementType> {
+
+    /**
+     * This class defines a set of image placements that are defined within this framework as standard.
+     * For all placements that use `background`, the image should use `aspect fill`. For all `icon` placements, the
+     * image should use `aspect fit`.
+     *
+     * - [IconBefore]:
+     *      Display the image "before" the content. For a portrait orientation, this would indicate that the image should
+     *      be displayed *above* the content. For landscape orientation, this would indicate that for languages that read
+     *      left to right, the image should be on the *left*.
+     * - [IconAfter]:
+     *      Display the image "after" the content. For portrait orientation, this would be *below* the content. For
+     *      landscape orientation for languages that read left to right, the image should be on the *right*.
+     * - [FullSizeBackground]:
+     *      Display the image full size in the background of the view.
+     * - [TopBackground]:
+     *      Top half of the background constrained to the top of the screen rather than to the safe area. On platforms that
+     *      support drawing the image under the status bar and in the area of the "notch", this would draw in that area.
+     * - [TopMarginBackground]:
+     *      Top half of the background constrained to the safe area.
+     * - [BackgroundBefore]:
+     *      Display the image "before" the content in the background. In portrait, this is equivalent to
+     *      [TopBackground] and in landscape for languages that read left to right, this would be the *left*
+     *      half of the view.
+     * - [BackgroundAfter]:
+     *      Display the image "after" the content in the background. In portrait, the image should display using
+     *      [TopBackground], but in landscape for languages that read left to right, this would display on the *right*
+     *      half of the view.
+     */
+    @Serializable
+    enum class Standard : ImagePlacementType {
+        IconBefore,
+        IconAfter,
+        FullSizeBackground,
+        TopBackground,
+        TopMarginBackground,
+        BackgroundBefore,
+        BackgroundAfter,
+        ;
+    }
+
+    @Serializable(with = ImagePlacementTypeSerializer::class)
+    data class Custom(override val name: String) : ImagePlacementType
+
+    override fun standardValues(): Array<ImagePlacementType> {
+        return Standard.values() as Array<ImagePlacementType>
+    }
+
+    override fun custom(name: String): ImagePlacementType {
+        return Custom(name)
+    }
+}
+
+/**
+ * Size is a simple serializable data class that includes the [width] and [height] of a drawable element. The dimensions
+ * are whatever unit is required by the implementing UI screens.
+ */
+@Serializable
+data class Size(val width: Double, val height: Double)

--- a/assessmentModel/src/commonMain/kotlin/serialization/Results.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/Results.kt
@@ -3,4 +3,6 @@ package org.sagebionetworks.assessmentmodel.serialization
 import org.sagebionetworks.assessmentmodel.CollectionResult
 import org.sagebionetworks.assessmentmodel.Result
 
-data class CollectionResultObject(override val identifier: String, override var pathResults: MutableList<Result> = mutableListOf(), override var asyncActionResults: MutableSet<Result> = mutableSetOf()) : CollectionResult
+data class CollectionResultObject(override val identifier: String,
+                                  override var pathHistoryResults: MutableList<Result> = mutableListOf(),
+                                  override var asyncActionResults: MutableSet<Result> = mutableSetOf()) : CollectionResult

--- a/assessmentModel/src/commonTest/kotlin/serialization/ImageTest.kt
+++ b/assessmentModel/src/commonTest/kotlin/serialization/ImageTest.kt
@@ -2,10 +2,7 @@ package org.sagebionetworks.assessmentmodel.serialization
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.modules.SerializersModule
 import org.sagebionetworks.assessmentmodel.ImageInfo
-import org.sagebionetworks.assessmentmodel.ImagePlacement
-import org.sagebionetworks.assessmentmodel.Size
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -32,8 +29,8 @@ open class ImageTest {
 
     @Test
     fun testFetchableImageWithValues() {
-        val image = FetchableImage("before", imagePlacement = ImagePlacement.Standard.BackgroundBefore, label = "Foo", imageSize = Size(width = 20, height = 40))
-        val inputString = """{"image":{"type":"fetchable","imageName":"before","label":"Foo","placementType":"BackgroundBefore","imageSize":{"width":20,"height":40}}}"""
+        val image = FetchableImage("before", imagePlacementType = ImagePlacement.Standard.BackgroundBefore, label = "Foo", size = Size(width = 20.0, height = 40.0))
+        val inputString = """{"image":{"type":"fetchable","imageName":"before","label":"Foo","placementType":"BackgroundBefore","size":{"width":20.0,"height":40.0}}}"""
 
         val original = TestImageWrapper(image)
         val jsonString = jsonCoder.stringify(TestImageWrapper.serializer(), original)


### PR DESCRIPTION
I changed the base interface to add some flexibility into how image layout works. The issue we discovered during development was that the designs would call for different image layouts for what was effectively the same "type" of screen. The idea we came up with at the time was the "ImagePlacementType" which is an extendable string enum. *Then* we needed some size information, *then* they wanted more customization of how the image layout was constrained, then we pointed out that it didn't work for all screen sizes *and*... here we are. :). Anyhow, since there are JSON files all over the place now that use this "hint", I wanted to support it but *not* require it.

Good times.

I also made some other changes to avoid naming clashes and for clarification.
