### PR TITLE
Update build to work with Android Studio 3.6

### DIFF
--- a/.idea/runConfigurations/ButtonTest.xml
+++ b/.idea/runConfigurations/ButtonTest.xml
@@ -1,14 +1,14 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="ButtonTest" type="JUnit" factoryName="JUnit">
+  <configuration default="false" name="ButtonTest" type="AndroidJUnit" factoryName="Android JUnit">
     <module name="assessmentModel" />
     <option name="PACKAGE_NAME" value="serialization" />
     <option name="MAIN_CLASS_NAME" value="org.sagebionetworks.assessmentmodel.serialization.ButtonTest" />
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="class" />
     <option name="PARAMETERS" value="" />
+    <option name="WORKING_DIRECTORY" value="$MODULE_DIR$" />
     <method v="2">
-      <option name="Make" enabled="true" />
-      <option name="Gradle.BeforeRunTask" enabled="false" tasks="bundleLibCompileDebugUnitTest" externalProjectPath="$PROJECT_DIR$/assessmentModel" vmOptions="" scriptParameters="" />
+      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
     </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/ImageTest.xml
+++ b/.idea/runConfigurations/ImageTest.xml
@@ -1,14 +1,14 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="ImageTest" type="JUnit" factoryName="JUnit" nameIsGenerated="true">
+  <configuration default="false" name="ImageTest" type="AndroidJUnit" factoryName="Android JUnit">
     <module name="assessmentModel" />
     <option name="PACKAGE_NAME" value="serialization" />
     <option name="MAIN_CLASS_NAME" value="org.sagebionetworks.assessmentmodel.serialization.ImageTest" />
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="class" />
     <option name="PARAMETERS" value="" />
+    <option name="WORKING_DIRECTORY" value="$MODULE_DIR$" />
     <method v="2">
-      <option name="Make" enabled="true" />
-      <option name="Gradle.BeforeRunTask" enabled="true" tasks="bundleLibCompileDebugUnitTest" externalProjectPath="$PROJECT_DIR$/assessmentModel" vmOptions="" scriptParameters="" />
+      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
     </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/InputItemsTest.xml
+++ b/.idea/runConfigurations/InputItemsTest.xml
@@ -1,14 +1,14 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="InputItemsTest" type="JUnit" factoryName="JUnit">
+  <configuration default="false" name="InputItemsTest" type="AndroidJUnit" factoryName="Android JUnit">
     <module name="assessmentModel" />
     <option name="PACKAGE_NAME" value="serialization" />
     <option name="MAIN_CLASS_NAME" value="org.sagebionetworks.assessmentmodel.serialization.InputItemsTest" />
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="class" />
     <option name="PARAMETERS" value="" />
+    <option name="WORKING_DIRECTORY" value="$MODULE_DIR$" />
     <method v="2">
-      <option name="Make" enabled="true" />
-      <option name="Gradle.BeforeRunTask" enabled="false" tasks="bundleLibCompileDebugUnitTest" externalProjectPath="$PROJECT_DIR$/assessmentModel" vmOptions="" scriptParameters="" />
+      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
     </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/NodeNavigatorTest.xml
+++ b/.idea/runConfigurations/NodeNavigatorTest.xml
@@ -1,14 +1,14 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="NodeNavigatorTest" type="JUnit" factoryName="JUnit">
+  <configuration default="false" name="NodeNavigatorTest" type="AndroidJUnit" factoryName="Android JUnit">
     <module name="assessmentModel" />
     <option name="PACKAGE_NAME" value="navigation" />
     <option name="MAIN_CLASS_NAME" value="org.sagebionetworks.assessmentmodel.navigation.NodeNavigatorTest" />
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="class" />
     <option name="PARAMETERS" value="" />
+    <option name="WORKING_DIRECTORY" value="$MODULE_DIR$" />
     <method v="2">
-      <option name="Make" enabled="true" />
-      <option name="Gradle.BeforeRunTask" enabled="true" tasks="bundleLibCompileDebugUnitTest" externalProjectPath="$PROJECT_DIR$/assessmentModel" vmOptions="" scriptParameters="" />
+      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
     </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/NodeTest.xml
+++ b/.idea/runConfigurations/NodeTest.xml
@@ -1,14 +1,14 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="NodeTest" type="JUnit" factoryName="JUnit">
+  <configuration default="false" name="NodeTest" type="AndroidJUnit" factoryName="Android JUnit">
     <module name="assessmentModel" />
     <option name="PACKAGE_NAME" value="serialization" />
     <option name="MAIN_CLASS_NAME" value="org.sagebionetworks.assessmentmodel.serialization.NodeTest" />
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="class" />
     <option name="PARAMETERS" value="" />
+    <option name="WORKING_DIRECTORY" value="$MODULE_DIR$" />
     <method v="2">
-      <option name="Make" enabled="true" />
-      <option name="Gradle.BeforeRunTask" enabled="false" tasks="bundleLibCompileDebugUnitTest" externalProjectPath="$PROJECT_DIR$/assessmentModel" vmOptions="" scriptParameters="" />
+      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
     </method>
   </configuration>
 </component>

--- a/.idea/runConfigurations/ResultTest.xml
+++ b/.idea/runConfigurations/ResultTest.xml
@@ -1,14 +1,14 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="ResultTest" type="JUnit" factoryName="JUnit">
+  <configuration default="false" name="ResultTest" type="AndroidJUnit" factoryName="Android JUnit">
     <module name="assessmentModel" />
     <option name="PACKAGE_NAME" value="serialization" />
     <option name="MAIN_CLASS_NAME" value="org.sagebionetworks.assessmentmodel.serialization.ResultTest" />
     <option name="METHOD_NAME" value="" />
     <option name="TEST_OBJECT" value="class" />
     <option name="PARAMETERS" value="" />
+    <option name="WORKING_DIRECTORY" value="$MODULE_DIR$" />
     <method v="2">
-      <option name="Make" enabled="true" />
-      <option name="Gradle.BeforeRunTask" enabled="true" tasks="bundleLibCompileDebugUnitTest" externalProjectPath="$PROJECT_DIR$/assessmentModel" vmOptions="" scriptParameters="" />
+      <option name="Android.Gradle.BeforeRunTask" enabled="true" />
     </method>
   </configuration>
 </component>

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,13 +1,13 @@
 plugins {
     id("com.android.application")
-    id("org.jetbrains.kotlin.multiplatform")
+    kotlin("android")
 }
 
 android {
     compileSdkVersion(29)
     defaultConfig {
         applicationId = "org.sagebionetworks.assessmentmodel.sampleapp"
-        minSdkVersion(15)
+        minSdkVersion(19)
         targetSdkVersion(29)
         versionCode = 1
         versionName = "1.0"
@@ -22,10 +22,15 @@ android {
         exclude("META-INF/main.kotlin_module")
         pickFirst("META-INF/kotlinx-serialization-runtime.kotlin_module")
     }
-}
+    viewBinding {
+        isEnabled = true
+    }
+    sourceSets {
+        getByName("main").java.srcDirs("src/main/kotlin")
+        getByName("test").java.srcDirs("src/main/kotlin")
+    }
 
-kotlin {
-    android()
+    testOptions.unitTests.isIncludeAndroidResources = true
 }
 
 dependencies {

--- a/assessmentModel/build.gradle.kts
+++ b/assessmentModel/build.gradle.kts
@@ -10,9 +10,9 @@ group = "org.sagebionetworks.assessmentmodel"
 version = 1.0
 
 android {
-    compileSdkVersion(27)
+    compileSdkVersion(29)
     defaultConfig {
-        minSdkVersion(15)
+        minSdkVersion(19)
     }
     buildTypes {
         getByName("release") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,21 @@
+# Project-wide Gradle settings.
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+org.gradle.jvmargs=-Xmx2048m
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=false
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app"s APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true
+# Automatically convert third-party libraries to use AndroidX
+android.enableJetifier=true
+# Kotlin code style for this project: "official" or "obsolete":
+kotlin.code.style=official

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,11 +1,15 @@
 pluginManagement {
+
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "com.android.library") {
-                useModule("com.android.tools.build:gradle:3.5.2")
+                useModule("com.android.tools.build:gradle:3.6.1")
             }
             if (requested.id.id == "com.android.application") {
-                useModule("com.android.tools.build:gradle:3.5.2")
+                useModule("com.android.tools.build:gradle:3.6.1")
+            }
+            if (requested.id.id == "org.jetbrains.kotlin.android") {
+                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")
             }
             if (requested.id.id == "org.jetbrains.kotlin.multiplatform") {
                 useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")


### PR DESCRIPTION
These changes allow us to use the latest release of Android Studio and take advantage of new features such as View Binding.  This will not work with Intellij 2019.x, as it depends on an older version of Android Studio.