### PR TITLE
Fixes to result serialization

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/AssessmentModel.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/AssessmentModel.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AssessmentModelTests"
+               BuildableName = "AssessmentModelTests"
+               BlueprintName = "AssessmentModelTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
         "state": {
           "branch": null,
-          "revision": "b7c8a6cdd55e119406893bd3f477e814229f2ae6",
-          "version": "1.4.3"
+          "revision": "03b89bfb11b342c7c6dd106bd5a909fab8201d89",
+          "version": "1.4.4"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,9 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "JsonModel",
+                 //path: "../JsonModel-Swift"),
                  url: "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
-                 from: "1.4.3"),
+                 from: "1.4.4"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/assessmentModel/src/commonMain/kotlin/Result.kt
+++ b/assessmentModel/src/commonMain/kotlin/Result.kt
@@ -123,4 +123,9 @@ interface AnswerResult : Result {
      * The answer held by this result.
      */
     var jsonValue: JsonElement?
+
+    /**
+     * The text of the question displayed to the participant.
+     */
+    val questionText: String?
 }

--- a/assessmentModel/src/commonMain/kotlin/serialization/InputItems.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/InputItems.kt
@@ -77,7 +77,7 @@ data class DoubleTextInputItemObject(@SerialName("identifier")
                                      var formatOptions: DoubleFormatOptions = DoubleFormatOptions())
     : InputItemObject<Double>() {
     override val answerType: AnswerType
-        get() = AnswerType.DECIMAL
+        get() = AnswerType.Decimal(significantDigits = formatOptions.maximumFractionDigits)
 
     override val keyboardOptions: KeyboardOptions
         get() = KeyboardOptionsObject.DecimalEntryOptions

--- a/assessmentModel/src/commonMain/kotlin/serialization/Results.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/Results.kt
@@ -37,7 +37,9 @@ data class AnswerResultObject(override val identifier: String,
                               override var startDateTime: Instant = Clock.System.now(),
                               @SerialName("endDate")
                               @Serializable(with = InstantSerializer::class)
-                              override var endDateTime: Instant? = null)
+                              override var endDateTime: Instant? = null,
+                              override val questionText: String? = null,
+                              val questionData: JsonElement? = null)
     : AnswerResult {
     override fun copyResult(identifier: String): AnswerResult = this.copy(identifier = identifier)
 }

--- a/assessmentModel/src/commonMain/kotlin/survey/AnswerType.kt
+++ b/assessmentModel/src/commonMain/kotlin/survey/AnswerType.kt
@@ -25,7 +25,7 @@ val answerTypeSerializersModule = SerializersModule {
         subclass(AnswerType.STRING::class)
         subclass(AnswerType.BOOLEAN::class)
         subclass(AnswerType.INTEGER::class)
-        subclass(AnswerType.DECIMAL::class)
+        subclass(AnswerType.Decimal::class)
     }
 }
 
@@ -109,7 +109,7 @@ abstract class AnswerType {
 
     @Serializable
     @SerialName("number")
-    object DECIMAL : AnswerType() {
+    data class Decimal(val significantDigits: Int? = null) : AnswerType() {
         override val baseType: BaseType
             get() = BaseType.NUMBER
     }
@@ -138,7 +138,7 @@ abstract class AnswerType {
             BaseType.BOOLEAN -> BOOLEAN
             BaseType.ARRAY -> Array()
             BaseType.OBJECT -> OBJECT
-            BaseType.NUMBER -> DECIMAL
+            BaseType.NUMBER -> Decimal()
             BaseType.INTEGER -> INTEGER
             BaseType.STRING -> STRING
         }
@@ -213,7 +213,7 @@ enum class BaseType : StringEnum {
             return values().matching(name) ?: throw SerializationException("Unknown $name for ${descriptor.serialName}. Needs to be one of ${values()}")
         }
         override fun serialize(encoder: Encoder, value: BaseType) {
-            encoder.encodeString(value.name)
+            encoder.encodeString(value.name.lowercase())
         }
     }
 }

--- a/assessmentModel/src/commonTest/kotlin/serialization/ResultTest.kt
+++ b/assessmentModel/src/commonTest/kotlin/serialization/ResultTest.kt
@@ -179,7 +179,7 @@ open class ResultTest {
     fun testAnswerType_Primitive_jsonElementFor() {
         assertEquals(JsonPrimitive(true), AnswerType.BOOLEAN.jsonElementFor(true))
         assertEquals(JsonPrimitive(3), AnswerType.INTEGER.jsonElementFor(3))
-        assertEquals(JsonPrimitive(3.2), AnswerType.DECIMAL.jsonElementFor(3.2))
+        assertEquals(JsonPrimitive(3.2), AnswerType.Decimal().jsonElementFor(3.2))
         assertEquals(JsonPrimitive("foo"), AnswerType.STRING.jsonElementFor("foo"))
     }
 
@@ -230,7 +230,7 @@ open class ResultTest {
     @Test
     fun testAnswerResult_Decimal() {
         val original = TestResultWrapper(
-            AnswerResultObject("foo", AnswerType.DECIMAL, JsonPrimitive(3.2), DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"), DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00")))
+            AnswerResultObject("foo", AnswerType.Decimal(4), JsonPrimitive(3.2), DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:00:00.000-03:00"), DateUtils.instantFromBridgeIsoDateTimeString("2020-01-21T12:05:00.000-03:00")))
         val inputString = """
                 { "result":
                     {
@@ -239,7 +239,8 @@ open class ResultTest {
                         "startDate": "2020-01-21T12:00:00.000-03:00",
                         "endDate": "2020-01-21T12:05:00.000-03:00",
                         "answerType" : {
-                            "type": "number"
+                            "type": "number",
+                            "significantDigits": 4
                         },
                         "value" : 3.2
                     }

--- a/assessmentModel/src/iosMain/kotlin/serialization/FileLoaderIOS.kt
+++ b/assessmentModel/src/iosMain/kotlin/serialization/FileLoaderIOS.kt
@@ -156,6 +156,19 @@ class AssessmentJsonResourceLoader(private val resourceName: String, bundle: NSB
     }
 }
 
+class ResultDecoder(private val jsonString: String) {
+    private val jsonCoder: Json = Serialization.JsonCoder.default
+    @Throws(Throwable::class)
+    fun decodeObject(): Result {
+        try {
+            val serializer = PolymorphicSerializer(Result::class)
+            return jsonCoder.decodeFromString(serializer, jsonString)
+        } catch (err: Exception) {
+            throw Throwable(err.message)
+        }
+    }
+}
+
 class ResultEncoder(private val result: Result) {
     private val jsonCoder: Json = Serialization.JsonCoder.default
     @Throws(Throwable::class)

--- a/iosApp/iosAppTests/KMMSerializationTests.swift
+++ b/iosApp/iosAppTests/KMMSerializationTests.swift
@@ -33,6 +33,7 @@
 
 import XCTest
 import AssessmentModel
+import JsonModel
 import KotlinModel
 
 class KMMSerializationTests: XCTestCase {
@@ -121,4 +122,70 @@ class KMMSerializationTests: XCTestCase {
             XCTAssertEqual(value.imageInfo?.imageName, swiftBtn.iconName)
         }
     }
+    
+    func testResultCodable() {
+        let factory = AssessmentFactory()
+        let encoder = factory.createJSONEncoder()
+        let decoder = factory.createJSONDecoder()
+
+        do {
+            let json = try encoder.encode(swiftAssessmentResult)
+            let jsonString = String(data: json, encoding: .utf8)!
+            print(jsonString)
+            
+            let loader = KotlinModel.ResultDecoder(jsonString: jsonString)
+            let kmmAssessmentResult = try loader.decodeObject() as? KotlinModel.AssessmentResultObject
+            XCTAssertNotNil(kmmAssessmentResult)
+            
+            guard let kmmAssessmentResult = kmmAssessmentResult else {
+                XCTFail("Failed to decode assessment result from the kotlin model.")
+                return
+            }
+            
+            let kmmEncoder = KotlinModel.ResultEncoder(result: kmmAssessmentResult)
+            let kmmJsonString = try kmmEncoder.encodeObject()
+            let kmmJson = kmmJsonString.data(using: .utf8)!
+            let decodedResult = try decoder.decode(AssessmentResultObject.self, from: kmmJson)
+            
+            checkResults(swiftResult: swiftAssessmentResult, decodedResult: decodedResult)
+
+        } catch {
+            XCTFail("Failed to encode or decode the assessment: \(error)")
+        }
+    }
+    
+    func checkResults(swiftResult: JsonModel.ResultData, decodedResult: JsonModel.ResultData) {
+        XCTAssertEqual(swiftResult.typeName, decodedResult.typeName, "\(swiftResult.identifier)")
+        XCTAssertEqual(swiftResult.identifier, decodedResult.identifier, "\(swiftResult.identifier)")
+        XCTAssertEqual(swiftResult.startDate.timeIntervalSinceReferenceDate, decodedResult.startDate.timeIntervalSinceReferenceDate, accuracy: 0.1, "\(swiftResult.identifier)")
+        XCTAssertEqual(swiftResult.endDate.timeIntervalSinceReferenceDate, decodedResult.endDate.timeIntervalSinceReferenceDate, accuracy: 0.1, "\(swiftResult.identifier)")
+        
+        if let answerResult = swiftResult as? JsonModel.AnswerResultObject {
+            if let decoded = decodedResult as? JsonModel.AnswerResultObject {
+                XCTAssertEqual(answerResult.questionText, decoded.questionText, "\(swiftResult.identifier)")
+                XCTAssertEqual(answerResult.questionData, decoded.questionData, "\(swiftResult.identifier)")
+                XCTAssertEqual(answerResult.jsonValue, decoded.jsonValue, "\(swiftResult.identifier)")
+                XCTAssertEqual(answerResult.jsonAnswerType?.typeName, decoded.jsonAnswerType?.typeName, "\(swiftResult.identifier)")
+            }
+            else {
+                XCTFail("Failed to decode the correct type. expected=\(swiftResult), actual=\(decodedResult)")
+            }
+        }
+        else if let branchResult = swiftResult as? JsonModel.BranchNodeResult {
+            if let decoded = decodedResult as? JsonModel.BranchNodeResult {
+                branchResult.stepHistory.forEach { childResult in
+                    if let decodedChild = decoded.stepHistory.first(where: { $0.identifier == childResult.identifier }) {
+                        checkResults(swiftResult: childResult, decodedResult: decodedChild)
+                    }
+                    else {
+                        XCTFail("Failed to decode the matching child. expected=\(childResult)")
+                    }
+                }
+            }
+            else {
+                XCTFail("Failed to decode the correct type. expected=\(swiftResult), actual=\(decodedResult)")
+            }
+        }
+    }
 }
+

--- a/iosWorkspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosWorkspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
         "state": {
           "branch": null,
-          "revision": "b7c8a6cdd55e119406893bd3f477e814229f2ae6",
-          "version": "1.4.3"
+          "revision": "03b89bfb11b342c7c6dd106bd5a909fab8201d89",
+          "version": "1.4.4"
         }
       }
     ]


### PR DESCRIPTION
Added result serialization for both Kotlin and Swift implementations. This tests the most common shared types of AssessmentResult, BranchNodeResult, and AnswerResult. 

TODO: Collection, File, Error