### PR TITLE
Add guid field to AssessmentInfo.

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.4.1")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1")
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
-    implementation("io.insert-koin:koin-android:3.1.1")
+    implementation("io.insert-koin:koin-android:3.1.5")
 
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
 

--- a/assessmentModel/src/commonMain/kotlin/Assessment.kt
+++ b/assessmentModel/src/commonMain/kotlin/Assessment.kt
@@ -32,6 +32,13 @@ interface BranchNode : Node {
 interface AssessmentInfo {
 
     /**
+     * The [guid] for the assessment. For assessments from Bridge this is the unique identifier
+     * for a particular revision of an assessment.
+     */
+    val guid: String?
+        get() = null
+
+    /**
      * The [identifier] for the assessment.
      */
     val identifier: String

--- a/assessmentModel/src/commonMain/kotlin/serialization/Nodes.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/Nodes.kt
@@ -145,6 +145,7 @@ data class AssessmentInfoObject(
     override val identifier: String,
     override val versionString: String? = null,
     override val schemaIdentifier: String? = null,
+    override val guid: String? = null,
     override val estimatedMinutes: Int = 0
 ) : AssessmentInfo
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
 }
 
 plugins {
-    id("org.jetbrains.dokka") version "1.4.0"
+    id("org.jetbrains.dokka") version "1.6.21"
     id("maven-publish")
 }
 

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1")
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
     implementation("androidx.core:core-ktx:1.7.0")
-    implementation("io.insert-koin:koin-android:3.1.1")
+    implementation("io.insert-koin:koin-android:3.1.5")
     implementation("androidx.legacy:legacy-support-v4:1.0.0")
     implementation("androidx.compose.ui:ui:${rootProject.extra["compose_version"]}")
     implementation("androidx.compose.material:material:${rootProject.extra["compose_version"]}")

--- a/presentation/src/main/java/org/sagebionetworks/assessmentmodel/presentation/compose/IntegerQuestionUi.kt
+++ b/presentation/src/main/java/org/sagebionetworks/assessmentmodel/presentation/compose/IntegerQuestionUi.kt
@@ -103,9 +103,10 @@ internal fun IntegerQuestion(
                 }
                 IntegerTextField(
                     modifier = Modifier
-                        .width(100.dp)
+                        .width(150.dp)
                         .align(Alignment.CenterHorizontally),
                     numberTextValue = numberTextValue,
+                    inputFieldLabel = uiFormatOptions.inputFieldLabel,
                     placeHolder = itemState.inputItem.placeholder,
                     updateAnswer = { value -> updateAnswer(value) },
                     isError = isError
@@ -167,41 +168,47 @@ private fun IntegerSlider(
 @Composable
 private fun IntegerTextField(
     numberTextValue: String,
+    inputFieldLabel: String?,
     updateAnswer: (String) -> Unit,
     placeHolder: String?,
     isError: Boolean,
     modifier: Modifier = Modifier
     ) {
-     val focusManager = LocalFocusManager.current
-     OutlinedTextField(
-         value = numberTextValue,
-         modifier = modifier,
-         singleLine = true,
-         onValueChange = {
-             updateAnswer(it)
-         },
-         label = {
-             if (placeHolder != null) {
-                 Text(placeHolder)
-             }
-         },
-         isError = isError,
-         keyboardOptions = KeyboardOptions(
-             keyboardType = KeyboardType.NumberPassword,
-             imeAction = ImeAction.Done
-         ),
-         keyboardActions = KeyboardActions(
-             onDone = {
-                 focusManager.clearFocus()
-             }),
-         textStyle = sageP2,
-         colors = TextFieldDefaults.textFieldColors(
-             backgroundColor = SageWhite,
-             cursorColor = SageBlack,
-             focusedIndicatorColor = SageBlack,
-             focusedLabelColor = SageBlack
-         )
-     )
+    val focusManager = LocalFocusManager.current
+    Column(modifier = modifier) {
+        inputFieldLabel?.let {
+            Text(text = it, style = sageP2)
+        }
+        OutlinedTextField(
+            value = numberTextValue,
+            //modifier = Modifier.align(Alignment.Start),
+            singleLine = true,
+            onValueChange = {
+                updateAnswer(it)
+            },
+            label = {
+                if (placeHolder != null) {
+                    Text(placeHolder)
+                }
+            },
+            isError = isError,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.NumberPassword,
+                imeAction = ImeAction.Done
+            ),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    focusManager.clearFocus()
+                }),
+            textStyle = sageP2,
+            colors = TextFieldDefaults.textFieldColors(
+                backgroundColor = SageWhite,
+                cursorColor = SageBlack,
+                focusedIndicatorColor = SageBlack,
+                focusedLabelColor = SageBlack
+            )
+        )
+    }
 }
 
 data class UiFormatOptions (
@@ -209,6 +216,7 @@ data class UiFormatOptions (
     val maxVal: Int?,
     val minLabel: String?,
     val maxLabel: String?,
+    val inputFieldLabel: String?,
     val showScale: Boolean,
     val startValue: Int?
 ) {
@@ -276,6 +284,7 @@ fun extractFormatOptions(questionState: QuestionState) : UiFormatOptions {
         maxVal = maxVal,
         minLabel = minLabel,
         maxLabel = maxLabel,
+        inputFieldLabel = inputItem.fieldLabel,
         showScale = showScale,
         startValue = startValue
     )


### PR DESCRIPTION
Add guid field to AssessmentInfo. This information is then included as part of the AssessmentPlaceholder that is passed to the AssessmentRegistryPovider. This allows for the creation of a Bridge survey AssessmentRegistryProvider, which will be part of the assessmentmodel-sdk module of BridgeClientKMM. I will create a PR for BridgeClientKMM once I have a build of AssessmentModel with this change.