### PR TITLE
Add support for the `guid` property to the iOS model objects

### DIFF
--- a/SwiftPackage/Sources/AssessmentModel/Assessment/Assessment.swift
+++ b/SwiftPackage/Sources/AssessmentModel/Assessment/Assessment.swift
@@ -158,10 +158,11 @@ public final class SectionObject : AbstractSectionObject, DocumentableStruct, Co
 
 open class AbstractAssessmentObject : AbstractNodeContainerObject, Assessment {
     private enum CodingKeys : String, OrderedEnumCodingKey, OpenOrderedCodingKey {
-        case jsonSchema = "$schema", versionString, estimatedMinutes, copyright, interruptionHandling
+        case jsonSchema = "$schema", versionString, estimatedMinutes, copyright, interruptionHandling, guid
         var relativeIndex: Int { 3 }
     }
     
+    public let guid: String?
     public let versionString: String?
     public let estimatedMinutes: Int
     public let copyright: String?
@@ -175,9 +176,10 @@ open class AbstractAssessmentObject : AbstractNodeContainerObject, Assessment {
     private let _jsonSchema: URL?
     
     public init(identifier: String, children: [Node],
-                version: String? = nil, estimatedMinutes: Int = 0, copyright: String? = nil, interruptionHandling: InterruptionHandlingObject? = nil,
+                guid: String? = nil, version: String? = nil, estimatedMinutes: Int = 0, copyright: String? = nil, interruptionHandling: InterruptionHandlingObject? = nil,
                 title: String? = nil, subtitle: String? = nil, detail: String? = nil, imageInfo: ImageInfo? = nil,
                 shouldHideButtons: Set<ButtonType>? = nil, buttonMap: [ButtonType : ButtonActionInfo]? = nil, comment: String? = nil) {
+        self.guid = guid
         self.versionString = version
         self.estimatedMinutes = estimatedMinutes
         self.copyright = copyright
@@ -189,6 +191,7 @@ open class AbstractAssessmentObject : AbstractNodeContainerObject, Assessment {
     }
     
     public init(identifier: String, copyFrom object: AbstractAssessmentObject) {
+        self.guid = object.guid
         self.versionString = object.versionString
         self.estimatedMinutes = object.estimatedMinutes
         self.copyright = object.copyright
@@ -199,6 +202,7 @@ open class AbstractAssessmentObject : AbstractNodeContainerObject, Assessment {
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.guid = try container.decodeIfPresent(String.self, forKey: .guid)
         self.versionString = try container.decodeIfPresent(String.self, forKey: .versionString)
         self.estimatedMinutes = try container.decodeIfPresent(Int.self, forKey: .estimatedMinutes) ?? 0
         self.copyright = try container.decodeIfPresent(String.self, forKey: .copyright)
@@ -210,6 +214,7 @@ open class AbstractAssessmentObject : AbstractNodeContainerObject, Assessment {
     open override func encode(to encoder: Encoder) throws {
         try super.encode(to: encoder)
         var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(self.guid, forKey: .guid)
         try container.encodeIfPresent(self.versionString, forKey: .versionString)
         try container.encodeIfPresent(self.copyright, forKey: .copyright)
         try container.encodeIfPresent(self._interruptionHandling, forKey: .interruptionHandling)
@@ -243,6 +248,9 @@ open class AbstractAssessmentObject : AbstractNodeContainerObject, Assessment {
             return try super.documentProperty(for: codingKey)
         }
         switch key {
+        case .guid:
+            return .init(propertyType: .primitive(.string), propertyDescription:
+                            "For assessments from Bridge this is the unique identifier for a particular revision of an assessment.")
         case .versionString:
             return .init(propertyType: .primitive(.string), propertyDescription:
                             "A version for the assessment.")

--- a/SwiftPackage/Sources/AssessmentModel/Assessment/AssessmentInterface.swift
+++ b/SwiftPackage/Sources/AssessmentModel/Assessment/AssessmentInterface.swift
@@ -123,6 +123,12 @@ public protocol OptionalNode : Node {
 
 /// Information about an assessment.
 public protocol AssessmentInfo {
+    
+    /// For assessments from Bridge this is the unique identifier for a particular revision of an assessment.
+    var guid: String? { get }
+    
+    /// The identifier used by a given library to uniquely identify the assessment within that library.
+    var identifier: String { get }
 
     /// The version of this assessment. This may be a semantic version, timestamp, or sequential revision integer.
     var versionString: String? { get }

--- a/assessmentModel/src/commonMain/kotlin/serialization/Nodes.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/Nodes.kt
@@ -202,6 +202,7 @@ data class AssessmentObject(
     override val identifier: String,
     @SerialName("steps")
     override val children: List<Node>,
+    override val guid: String? = null,
     override val versionString: String? = null,
     override val schemaIdentifier: String? = null,
     override var estimatedMinutes: Int = 0,
@@ -219,7 +220,8 @@ data class AssessmentObject(
             it.unpack(null, moduleInfo, registryProvider)
         }
         val identifier = originalNode?.identifier ?: this.identifier
-        val copy = copy(identifier = identifier, children = copyChildren)
+        val guid = originalNode?.identifier ?: this.guid
+        val copy = copy(identifier = identifier, guid = guid, children = copyChildren)
         copy.copyFrom(this)
         return copy
     }


### PR DESCRIPTION
and unpack the `AssessmentObject` to use the guid from the transformable.

iOS and Android do not share a model so stuff that you want to use in Bridge from the Kotlin model also needs to be added to the Swift model. Also, I'm thinking you meant for the assessment to unpack and hold onto the guid so I added that to the Kotlin code.