### PR TITLE
Add duration and time to the Kotlin serialization model

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
         "state": {
           "branch": null,
-          "revision": "b828a14b255c849199032b6d7eaec0e6be025115",
-          "version": "1.4.6"
+          "revision": "ddde0196c6e85b9adcfc3c5436b31b26f033f386",
+          "version": "1.4.7"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     dependencies: [
         .package(name: "JsonModel",
                  url: "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
-                 from: "1.4.6"),
+                 from: "1.4.7"),
         .package(name: "SharedMobileUI",
                  url: "https://github.com/Sage-Bionetworks/SharedMobileUI-AppleOS.git",
                  from: "0.15.0"),

--- a/assessmentModel/src/commonMain/kotlin/serialization/InputItems.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/InputItems.kt
@@ -12,7 +12,6 @@ import org.sagebionetworks.assessmentmodel.survey.AnswerType
 val inputItemSerializersModule = SerializersModule {
     polymorphic(InputItem::class) {
         subclass(CheckboxInputItemObject::class)
-        subclass(DateInputItemObject::class)
         subclass(DoubleTextInputItemObject::class)
         subclass(DurationInputItemObject::class)
         subclass(IntegerTextInputItemObject::class)
@@ -21,16 +20,11 @@ val inputItemSerializersModule = SerializersModule {
         subclass(YearTextInputItemObject::class)
     }
     polymorphic(KeyboardTextInputItem::class) {
-        subclass(DateInputItemObject::class)
         subclass(DoubleTextInputItemObject::class)
         subclass(IntegerTextInputItemObject::class)
         subclass(StringTextInputItemObject::class)
         subclass(TimeInputItemObject::class)
         subclass(YearTextInputItemObject::class)
-    }
-    polymorphic(DateTimeFormatOptions::class) {
-        subclass(DateFormatOptions::class)
-        subclass(TimeFormatOptions::class)
     }
 }
 
@@ -152,47 +146,22 @@ data class YearTextInputItemObject(@SerialName("identifier")
 data class DurationInputItemObject(
     @SerialName("identifier")
     override val resultIdentifier: String? = null,
-    override val displayUnits: List<String> = listOf("H","M"),
+    override val displayUnits: List<DurationUnit> = DurationUnit.defaultUnits,
     override var optional: Boolean = true,
     override var exclusive: Boolean = false
 ) : DurationInputItem
 
 /**
- * DateTimeInputItem
+ * TimeInputItem
  */
 
 @Serializable
-@SerialName("date")
-data class DateInputItemObject(@SerialName("identifier")
-                                   override val resultIdentifier: String? = null,
-                                   override var formatOptions: DateFormatOptions = DateFormatOptions())
-    : InputItemObject<String>(), DateTimeInputItem
-
-@Serializable
 @SerialName("time")
-data class TimeInputItemObject(@SerialName("identifier")
-                                   override val resultIdentifier: String? = null,
-                                   override var formatOptions: TimeFormatOptions = TimeFormatOptions())
-    : InputItemObject<String>(), DateTimeInputItem {
-    override val answerType: AnswerType
-        get() = AnswerType.Time(formatOptions.codingFormat)
-}
-
-@Serializable
-@SerialName("date")
-data class DateFormatOptions(override val allowFuture: Boolean = true,
-                             override val allowPast: Boolean = true,
-                             override val minimumValue: String? = null,
-                             override val maximumValue: String? = null,
-                             override val codingFormat: String = ISO8601Format.DateOnly.formatString) : DateTimeFormatOptions
-
-@Serializable
-@SerialName("time")
-data class TimeFormatOptions(override val allowFuture: Boolean = true,
-                             override val allowPast: Boolean = true,
-                             override val minimumValue: String? = null,
-                             override val maximumValue: String? = null,
-                             override val codingFormat: String = ISO8601Format.TimeOnly.formatString) : DateTimeFormatOptions
+data class TimeInputItemObject(
+    @SerialName("identifier")
+    override val resultIdentifier: String? = null,
+    override var formatOptions: TimeFormatOptions = TimeFormatOptions()
+) : InputItemObject<String>(), TimeInputItem
 
 /**
  * ChoiceInputItem

--- a/assessmentModel/src/commonMain/kotlin/serialization/InputItems.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/InputItems.kt
@@ -14,6 +14,7 @@ val inputItemSerializersModule = SerializersModule {
         subclass(CheckboxInputItemObject::class)
         subclass(DateInputItemObject::class)
         subclass(DoubleTextInputItemObject::class)
+        subclass(DurationInputItemObject::class)
         subclass(IntegerTextInputItemObject::class)
         subclass(StringTextInputItemObject::class)
         subclass(TimeInputItemObject::class)
@@ -143,6 +144,20 @@ data class YearTextInputItemObject(@SerialName("identifier")
 }
 
 /**
+ * Duration
+ */
+
+@Serializable
+@SerialName("duration")
+data class DurationInputItemObject(
+    @SerialName("identifier")
+    override val resultIdentifier: String? = null,
+    override val displayUnits: List<String> = listOf("H","M"),
+    override var optional: Boolean = true,
+    override var exclusive: Boolean = false
+) : DurationInputItem
+
+/**
  * DateTimeInputItem
  */
 
@@ -158,7 +173,10 @@ data class DateInputItemObject(@SerialName("identifier")
 data class TimeInputItemObject(@SerialName("identifier")
                                    override val resultIdentifier: String? = null,
                                    override var formatOptions: TimeFormatOptions = TimeFormatOptions())
-    : InputItemObject<String>(), DateTimeInputItem
+    : InputItemObject<String>(), DateTimeInputItem {
+    override val answerType: AnswerType
+        get() = AnswerType.Time(formatOptions.codingFormat)
+}
 
 @Serializable
 @SerialName("date")

--- a/assessmentModel/src/commonMain/kotlin/survey/AnswerType.kt
+++ b/assessmentModel/src/commonMain/kotlin/survey/AnswerType.kt
@@ -62,7 +62,7 @@ abstract class AnswerType {
     }
 
     @Serializable
-    @SerialName("dateTime")
+    @SerialName("date-time")
     data class DateTime(val codingFormat: String = ISO8601Format.Timestamp.formatString) : AnswerType() {
         override val baseType: BaseType
             get() = BaseType.STRING

--- a/assessmentModel/src/commonMain/kotlin/survey/AnswerType.kt
+++ b/assessmentModel/src/commonMain/kotlin/survey/AnswerType.kt
@@ -19,6 +19,8 @@ import org.sagebionetworks.assessmentmodel.serialization.AnswerResultObject
 val answerTypeSerializersModule = SerializersModule {
     polymorphic(AnswerType::class) {
         subclass(AnswerType.DateTime::class)
+        subclass(AnswerType.Time::class)
+        subclass(AnswerType.Duration::class)
         subclass(AnswerType.Array::class)
         subclass(AnswerType.Measurement::class)
         subclass(AnswerType.OBJECT::class)
@@ -61,9 +63,25 @@ abstract class AnswerType {
 
     @Serializable
     @SerialName("dateTime")
-    data class DateTime(val codingFormat: String = ISO8601Format.DateOnly.formatString) : AnswerType() {
+    data class DateTime(val codingFormat: String = ISO8601Format.Timestamp.formatString) : AnswerType() {
         override val baseType: BaseType
             get() = BaseType.STRING
+    }
+
+    @Serializable
+    @SerialName("time")
+    data class Time(val codingFormat: String = ISO8601Format.TimeOnly.formatString) : AnswerType() {
+        override val baseType: BaseType
+            get() = BaseType.STRING
+    }
+
+    @Serializable
+    @SerialName("duration")
+    data class Duration(
+        val displayUnits: List<String> = listOf("H","M")
+    ) : AnswerType() {
+        override val baseType: BaseType
+            get() = BaseType.NUMBER
     }
 
     @Serializable

--- a/assessmentModel/src/commonMain/kotlin/survey/AnswerType.kt
+++ b/assessmentModel/src/commonMain/kotlin/survey/AnswerType.kt
@@ -78,7 +78,7 @@ abstract class AnswerType {
     @Serializable
     @SerialName("duration")
     data class Duration(
-        val displayUnits: List<String> = listOf("H","M")
+        val displayUnits: List<DurationUnit> = DurationUnit.defaultUnits
     ) : AnswerType() {
         override val baseType: BaseType
             get() = BaseType.NUMBER

--- a/assessmentModel/src/commonMain/kotlin/survey/InputItem.kt
+++ b/assessmentModel/src/commonMain/kotlin/survey/InputItem.kt
@@ -261,7 +261,7 @@ interface DurationInputItem : InputItem {
         get() = DurationUnit.defaultUnits
 
     override val answerType: AnswerType
-        get() = AnswerType.Duration(displayUnits.map { it.name })
+        get() = AnswerType.Duration(displayUnits)
 }
 
 @Serializable

--- a/assessmentModel/src/commonMain/kotlin/survey/InputItem.kt
+++ b/assessmentModel/src/commonMain/kotlin/survey/InputItem.kt
@@ -238,17 +238,6 @@ data class TimeFormatOptions(val allowFuture: Boolean = true,
                              val minimumValue: String? = null,
                              val maximumValue: String? = null)
 
-/**
- * The [DateTimeFormatOptions] is a serializable representation of the date or time range to allow for a question as
- * well as what parts of the date or time are requested by the question.
- */
-interface DateTimeFormatOptions {
-    val allowFuture: Boolean
-    val allowPast: Boolean
-    val minimumValue: String?
-    val maximumValue: String?
-}
-
 object PassThruTextValidator : TextValidator<String> {
     override fun valueFor(text: String): FormattedValue<String>? = FormattedValue(text)
     override fun localizedStringFor(value: String?): FormattedValue<String> = FormattedValue(value)

--- a/assessmentModel/src/commonMain/kotlin/survey/InputItem.kt
+++ b/assessmentModel/src/commonMain/kotlin/survey/InputItem.kt
@@ -262,3 +262,10 @@ object PassThruTextValidator : TextValidator<String> {
     override fun jsonValueFor(value: String?): JsonElement? = JsonPrimitive(value)
     override fun valueFor(jsonValue: JsonElement?): String? = jsonValue?.jsonPrimitive?.content
 }
+
+interface DurationInputItem : InputItem {
+    val displayUnits: List<String>
+
+    override val answerType: AnswerType
+        get() = AnswerType.Duration(displayUnits)
+}

--- a/assessmentModel/src/commonTest/kotlin/serialization/InputItemsTest.kt
+++ b/assessmentModel/src/commonTest/kotlin/serialization/InputItemsTest.kt
@@ -621,7 +621,7 @@ open class InputItemsTest {
             "placeholder": "Blue, no! Red!",
             "formatOptions" : {
                         "minimumValue" : "06:00",
-                        "allowFuture" : false,
+                        "allowFuture" : false
             }
            }
            """
@@ -677,6 +677,48 @@ open class InputItemsTest {
            }
            """
         val original = TimeInputItemObject()
+
+        val serializer = PolymorphicSerializer(InputItem::class)
+        val jsonString = jsonCoder.encodeToString(serializer, original)
+        val restored = jsonCoder.decodeFromString(serializer, jsonString)
+        val decoded = jsonCoder.decodeFromString(serializer, inputString)
+
+        assertEquals(original, restored)
+        assertEquals(original, decoded)
+    }
+
+    /**
+     * DurationInputItemObject
+     */
+
+    @Test
+    fun testDurationInputItemObject_Default_Serialization() {
+        val inputString = """
+           {
+            "type": "duration"
+           }
+           """
+        val original = DurationInputItemObject()
+
+        val serializer = PolymorphicSerializer(InputItem::class)
+        val jsonString = jsonCoder.encodeToString(serializer, original)
+        val restored = jsonCoder.decodeFromString(serializer, jsonString)
+        val decoded = jsonCoder.decodeFromString(serializer, inputString)
+
+        assertEquals(original, restored)
+        assertEquals(original, decoded)
+    }
+
+
+    @Test
+    fun testDurationInputItemObject_DisplayUnits_Serialization() {
+        val inputString = """
+           {
+            "type": "duration",
+            "displayUnits": ["minute","second"]
+           }
+           """
+        val original = DurationInputItemObject(displayUnits = listOf(DurationUnit.Minute, DurationUnit.Second))
 
         val serializer = PolymorphicSerializer(InputItem::class)
         val jsonString = jsonCoder.encodeToString(serializer, original)

--- a/assessmentModel/src/commonTest/kotlin/serialization/InputItemsTest.kt
+++ b/assessmentModel/src/commonTest/kotlin/serialization/InputItemsTest.kt
@@ -195,90 +195,6 @@ open class InputItemsTest {
     }
 
     /**
-     * DateInputItemObject
-     */
-
-    @Test
-    fun testDateInputItemObject_Min_Serialization() {
-        val inputString = """
-           {
-            "identifier": "foo",
-            "type": "date",
-            "fieldLabel": "Favorite color",
-            "placeholder": "Blue, no! Red!",
-            "formatOptions" : {
-                        "minimumValue" : "1900-01",
-                        "allowFuture" : false,
-                        "codingFormat" : "yyyy-MM"
-            }
-           }
-           """
-        val original = DateInputItemObject(
-                resultIdentifier = "foo",
-                formatOptions = DateFormatOptions(
-                        minimumValue = "1900-01",
-                        allowFuture = false,
-                        codingFormat = "yyyy-MM"))
-
-        val serializer = PolymorphicSerializer(InputItem::class)
-        val jsonString = jsonCoder.encodeToString(serializer, original)
-        val restored = jsonCoder.decodeFromString(serializer, jsonString)
-        val decoded = jsonCoder.decodeFromString(serializer, inputString)
-
-        assertEquals(original, restored)
-        assertEquals(original, decoded)
-    }
-
-    @Test
-    fun testDateInputItemObject_Max_Serialization() {
-        val inputString = """
-           {
-            "identifier": "foo",
-            "type": "date",
-            "fieldLabel": "Favorite color",
-            "placeholder": "Blue, no! Red!",
-            "formatOptions" : {
-                        "allowPast" : false,
-                        "maximumValue" : "2100-01",
-                        "codingFormat" : "yyyy-MM"
-            }
-           }
-           """
-        val original = DateInputItemObject(
-                resultIdentifier = "foo",
-                formatOptions = DateFormatOptions(
-                        allowPast = false,
-                        maximumValue = "2100-01",
-                        codingFormat = "yyyy-MM"))
-
-        val serializer = PolymorphicSerializer(InputItem::class)
-        val jsonString = jsonCoder.encodeToString(serializer, original)
-        val restored = jsonCoder.decodeFromString(serializer, jsonString)
-        val decoded = jsonCoder.decodeFromString(serializer, inputString)
-
-        assertEquals(original, restored)
-        assertEquals(original, decoded)
-    }
-
-    @Test
-    fun testDateInputItemObject_Default_Serialization() {
-        val inputString = """
-           {
-            "type": "date"
-           }
-           """
-        val original = DateInputItemObject()
-
-        val serializer = PolymorphicSerializer(InputItem::class)
-        val jsonString = jsonCoder.encodeToString(serializer, original)
-        val restored = jsonCoder.decodeFromString(serializer, jsonString)
-        val decoded = jsonCoder.decodeFromString(serializer, inputString)
-
-        assertEquals(original, restored)
-        assertEquals(original, decoded)
-    }
-
-    /**
      * [DoubleTextInputItemObject] Tests
      */
 
@@ -706,7 +622,6 @@ open class InputItemsTest {
             "formatOptions" : {
                         "minimumValue" : "06:00",
                         "allowFuture" : false,
-                        "codingFormat" : "HH:mm"
             }
            }
            """
@@ -714,8 +629,7 @@ open class InputItemsTest {
                 resultIdentifier = "foo",
                 formatOptions = TimeFormatOptions(
                         minimumValue = "06:00",
-                        allowFuture = false,
-                        codingFormat = "HH:mm"))
+                        allowFuture = false))
 
         val serializer = PolymorphicSerializer(InputItem::class)
         val jsonString = jsonCoder.encodeToString(serializer, original)
@@ -736,8 +650,7 @@ open class InputItemsTest {
             "placeholder": "Blue, no! Red!",
             "formatOptions" : {
                         "allowPast" : false,
-                        "maximumValue" : "22:00",
-                        "codingFormat" : "HH:mm"
+                        "maximumValue" : "22:00"
             }
            }
            """
@@ -745,8 +658,7 @@ open class InputItemsTest {
                 resultIdentifier = "foo",
                 formatOptions = TimeFormatOptions(
                         allowPast = false,
-                        maximumValue = "22:00",
-                        codingFormat = "HH:mm"))
+                        maximumValue = "22:00"))
 
         val serializer = PolymorphicSerializer(InputItem::class)
         val jsonString = jsonCoder.encodeToString(serializer, original)

--- a/assessmentModel/src/commonTest/kotlin/serialization/ResultTest.kt
+++ b/assessmentModel/src/commonTest/kotlin/serialization/ResultTest.kt
@@ -359,7 +359,7 @@ open class ResultTest {
                         "startDate": "2020-01-21T12:00:00.000-03:00",
                         "endDate": "2020-01-21T12:05:00.000-03:00",
                         "answerType" : {
-                            "type": "dateTime",
+                            "type": "date-time",
                             "codingFormat": "yyyy-MM"
                         },
                         "value" : "2020-02"


### PR DESCRIPTION
This doesn't handle creating an appropriate question state or anything. Wasn't sure how best to handle this since it's super-weird but figured I would go ahead and add the serialization so that it was consistent. (I'll need to add it to the JsonModel-Swift project on iOS before adding the Swift input item.)

Also, we may want to consider adding a new question type with multiple input items rather than an input item that maps to a simple question? Idano. what do you think?

https://github.com/Sage-Bionetworks/JsonModel-Swift/pull/17
