### PR TITLE
BMC-370 iOS - Restore state from previous assessment result

### DIFF
--- a/SwiftPackage/Sources/AssessmentModelUI/ViewModels/AssessmentViewModel.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/ViewModels/AssessmentViewModel.swift
@@ -95,7 +95,7 @@ open class AssessmentViewModel : ObservableObject, NavigationState {
     }
     
     private func reviewNode() -> Node? {
-        guard let reviewIdentifier = self.state.interuptionHandling.reviewIdentifier
+        guard let reviewIdentifier = self.state.interruptionHandling.reviewIdentifier
         else {
             return nil
         }
@@ -322,7 +322,7 @@ open class AssessmentViewModel : ObservableObject, NavigationState {
     }
     
     open func canPauseAssessment(step: Step) -> Bool {
-        guard state.interuptionHandling.canPause &&
+        guard state.interruptionHandling.canPause &&
               !shouldHide(.navigation(.pause), step: step)
         else {
             return false

--- a/SwiftPackage/Sources/AssessmentModelUI/ViewModels/NodeState.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/ViewModels/NodeState.swift
@@ -90,7 +90,7 @@ public final class AssessmentState : BranchState {
     public var assessment: Assessment { node as! Assessment }
     public var assessmentResult: AssessmentResult { result as! AssessmentResult }
     
-    public let interuptionHandling: InterruptionHandling
+    public let interruptionHandling: InterruptionHandling
 
     @Published public var status: Status = .running
     @Published public var currentStep: StepState?
@@ -99,8 +99,9 @@ public final class AssessmentState : BranchState {
     @Published public var navigationError: Error?
 
     public init(_ assessment: Assessment, restoredResult: AssessmentResult? = nil, interuptionHandling: InterruptionHandling? = nil) {
-        let result = restoredResult ?? assessment.instantiateAssessmentResult()
-        self.interuptionHandling = interuptionHandling ?? assessment.interruptionHandling
+        let rules = interuptionHandling ?? assessment.interruptionHandling
+        let result = restoredResult.flatMap { rules.canSaveForLater ? $0.deepCopy() : nil } ?? assessment.instantiateAssessmentResult()
+        self.interruptionHandling = rules
         super.init(branch: assessment, result: result)
     }
     

--- a/SwiftPackage/Sources/AssessmentModelUI/ViewModels/NodeState.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/ViewModels/NodeState.swift
@@ -98,8 +98,8 @@ public final class AssessmentState : BranchState {
     @Published public var canPause: Bool = false
     @Published public var navigationError: Error?
 
-    public init(_ assessment: Assessment, restoredResult: AssessmentResult? = nil, interuptionHandling: InterruptionHandling? = nil) {
-        let rules = interuptionHandling ?? assessment.interruptionHandling
+    public init(_ assessment: Assessment, restoredResult: AssessmentResult? = nil, interruptionHandling: InterruptionHandling? = nil) {
+        let rules = interruptionHandling ?? assessment.interruptionHandling
         let result = restoredResult.flatMap { rules.canSaveForLater ? $0.deepCopy() : nil } ?? assessment.instantiateAssessmentResult()
         self.interruptionHandling = rules
         super.init(branch: assessment, result: result)

--- a/SwiftPackage/Sources/AssessmentModelUI/Views/Components/PauseMenu.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/Views/Components/PauseMenu.swift
@@ -56,19 +56,19 @@ struct PauseMenu: View {
             Spacer()
             
             VStack(spacing: innerSpacing) {
-                if assessmentState.interuptionHandling.canResume {
+                if assessmentState.interruptionHandling.canResume {
                     Button(action: viewModel.resume) {
                         Text("Resume", bundle: .module)
                     }
                     .buttonStyle(PrimaryButtonStyle())
                 }
-                if assessmentState.interuptionHandling.reviewIdentifier != nil {
+                if assessmentState.interruptionHandling.reviewIdentifier != nil {
                     Button(action: viewModel.reviewInstructions) {
                         Text("Review instructions", bundle: .module)
                     }
                     .buttonStyle(SecondaryButtonStyle())
                 }
-                if assessmentState.interuptionHandling.canSkip {
+                if assessmentState.interruptionHandling.canSkip {
                     Button(action: viewModel.skipAssessment) {
                         Text("Skip this activity", bundle: .module)
                     }

--- a/SwiftPackage/Tests/AssessmentModelTests/AssessmentTests/NavigationTests/NodeNavigatorTests.swift
+++ b/SwiftPackage/Tests/AssessmentModelTests/AssessmentTests/NavigationTests/NodeNavigatorTests.swift
@@ -66,6 +66,11 @@ class NodeNavigatorTests: XCTestCase {
         
         let multipleChoiceResult = followupNavigationSurveyA(state, expectedPrevious: "choiceQ1")
         XCTAssertNotNil(multipleChoiceResult)
+        
+        let restoredState = TestNavigationState(surveyA, restoredResult: state.assessmentResult)
+        let restoredNode = restoredState.nodeNavigator.nodeAfter(currentNode: nil, branchResult: restoredState.assessmentResult)
+        XCTAssertEqual("multipleChoice", restoredNode.node?.identifier)
+        XCTAssertEqual(.forward, restoredNode.direction)
     }
     
     func testSurveyANavigation_Q3() {
@@ -94,6 +99,11 @@ class NodeNavigatorTests: XCTestCase {
         
         let multipleChoiceResult = followupNavigationSurveyA(state, expectedPrevious: "simpleQ3")
         XCTAssertNotNil(multipleChoiceResult)
+        
+        let restoredState = TestNavigationState(surveyA, restoredResult: state.assessmentResult)
+        let restoredNode = restoredState.nodeNavigator.nodeAfter(currentNode: nil, branchResult: restoredState.assessmentResult)
+        XCTAssertEqual("multipleChoice", restoredNode.node?.identifier)
+        XCTAssertEqual(.forward, restoredNode.direction)
     }
 
     
@@ -179,9 +189,9 @@ class NodeNavigatorTests: XCTestCase {
         
         var currentNode: Node?
         
-        init(_ assessment: AssessmentObject) {
+        init(_ assessment: AssessmentObject, restoredResult: AssessmentResultObject? = nil) {
             self.assessment = assessment
-            self.assessmentResult = assessment.instantiateAssessmentResult() as! AssessmentResultObject
+            self.assessmentResult = restoredResult?.deepCopy() ?? assessment.instantiateAssessmentResult() as! AssessmentResultObject
             self.nodeNavigator = try! assessment.instantiateNavigator(state: self) as! NodeNavigator
         }
     }

--- a/SwiftPackage/Tests/AssessmentModelUITests/AssessmentNavigationTests.swift
+++ b/SwiftPackage/Tests/AssessmentModelUITests/AssessmentNavigationTests.swift
@@ -106,6 +106,18 @@ class AssessmentNavigationTests: XCTestCase {
                 XCTAssertNil(result.endDateTime)
             }
         }
+        
+        // Check restored state
+        guard let expectedNode = taskController.assessmentState.currentStep?.node
+        else {
+            XCTFail("Expected the current node to be non-nil")
+            return
+        }
+        let restoredController = TestAssessmentController(steps, restoredResult: taskController.assessmentState.assessmentResult)
+        let restoredState = restoredController.assessmentState.currentStep
+        XCTAssertEqual(expectedNode.identifier, restoredState?.node.identifier)
+        XCTAssertEqual(expectedNode.typeName, restoredState?.node.typeName)
+        XCTAssertEqual(.forward, restoredController.viewModel.navigationViewModel.currentDirection)
     }
     
     func testNavigation_BackFrom5X() {
@@ -137,6 +149,18 @@ class AssessmentNavigationTests: XCTestCase {
         
         XCTAssertEqual(.backward, taskController.viewModel.navigationViewModel.currentDirection)
         XCTAssertTrue(taskController.viewModel.navigationViewModel.backEnabled)
+        
+        // Check restored state
+        guard let expectedNode = taskController.assessmentState.currentStep?.node
+        else {
+            XCTFail("Expected the current node to be non-nil")
+            return
+        }
+        let restoredController = TestAssessmentController(steps, restoredResult: taskController.assessmentState.assessmentResult)
+        let restoredState = restoredController.assessmentState.currentStep
+        XCTAssertEqual(expectedNode.identifier, restoredState?.node.identifier)
+        XCTAssertEqual(expectedNode.typeName, restoredState?.node.typeName)
+        XCTAssertEqual(.forward, restoredController.viewModel.navigationViewModel.currentDirection)
     }
 
     func testNavigation_BackFrom5Z() {
@@ -168,6 +192,18 @@ class AssessmentNavigationTests: XCTestCase {
         
         XCTAssertEqual(.backward, taskController.viewModel.navigationViewModel.currentDirection)
         XCTAssertTrue(taskController.viewModel.navigationViewModel.backEnabled)
+        
+        // Check restored state
+        guard let expectedNode = taskController.assessmentState.currentStep?.node
+        else {
+            XCTFail("Expected the current node to be non-nil")
+            return
+        }
+        let restoredController = TestAssessmentController(steps, restoredResult: taskController.assessmentState.assessmentResult)
+        let restoredState = restoredController.assessmentState.currentStep
+        XCTAssertEqual(expectedNode.identifier, restoredState?.node.identifier)
+        XCTAssertEqual(expectedNode.typeName, restoredState?.node.typeName)
+        XCTAssertEqual(.forward, restoredController.viewModel.navigationViewModel.currentDirection)
     }
 }
 
@@ -192,9 +228,9 @@ class TestAssessmentController {
     let assessmentState: AssessmentState
     let viewModel: AssessmentViewModel
     
-    init(_ children: [Node]) {
+    init(_ children: [Node], restoredResult: AssessmentResult? = nil) {
         let assessment = AssessmentObject(identifier: "test", children: children)
-        let assessmentState = AssessmentState(assessment)
+        let assessmentState = AssessmentState(assessment, restoredResult: restoredResult)
         let viewModel = AssessmentViewModel()
         viewModel.initialize(assessmentState, viewVender: TestAssessmentStepViewVender())
         


### PR DESCRIPTION
On iOS, the simplest path for setting up an assessment state with a restored result was to modify the navigator to look at the input result for a path marker. 

Note: I don't include any serialization handling b/c that will have to be in the BridgeClient which knows about both SageResearch and AssessmentModel b/c they use a shared class for result deserialization that is defined in SageResearch.