### PR TITLE
Add completion view to match the designs in the survey builder

### DIFF
--- a/SwiftPackage/Sources/AssessmentModelUI/Resources/Images.xcassets/completion/Contents.json
+++ b/SwiftPackage/Sources/AssessmentModelUI/Resources/Images.xcassets/completion/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftPackage/Sources/AssessmentModelUI/Resources/Images.xcassets/completion/completion.0.imageset/Contents.json
+++ b/SwiftPackage/Sources/AssessmentModelUI/Resources/Images.xcassets/completion/completion.0.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "completion_background.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "original"
+  }
+}

--- a/SwiftPackage/Sources/AssessmentModelUI/Resources/Images.xcassets/completion/completion.0.imageset/completion_background.svg
+++ b/SwiftPackage/Sources/AssessmentModelUI/Resources/Images.xcassets/completion/completion.0.imageset/completion_background.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="272" height="179" viewBox="0 0 272 179" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="140.775" cy="113.502" r="47.5" fill="#3A3A3A"/>
+  <circle r="2" transform="matrix(-1 0 0 1 176.275 60.002)" fill="#2A2929"/>
+  <circle r="2" transform="matrix(-1 0 0 1 134.275 171.002)" fill="#FFE500"/>
+  <circle r="2" transform="matrix(-1 0 0 1 85 74)" fill="#FFE500"/>
+  <path d="M68.732 114.69L75.0461 116.435L70.3784 121.031L68.732 114.69Z" fill="#54A2DB"/>
+  <path d="M237.357 12.1593L240.916 15.8993L235.897 17.1119L237.357 12.1593Z" fill="#54A2DB"/>
+  <rect x="267.885" y="42" width="6.69532" height="6.69532" transform="rotate(61.476 267.885 42)" fill="#E98686"/>
+  <rect x="140.512" y="36.2832" width="3.6004" height="3.6004" transform="rotate(30 140.512 36.2832)" fill="#E98686"/>
+  <rect x="19.8008" y="140" width="3.6004" height="3.6004" transform="rotate(30 19.8008 140)" fill="#E98686"/>
+  <rect x="61.1426" y="101.867" width="4.66311" height="4.66311" transform="rotate(113.605 61.1426 101.867)" fill="#E98686"/>
+  <circle r="2" transform="matrix(-1 0 0 1 51 136)" fill="#2A2929"/>
+  <circle r="1" transform="matrix(-1 0 0 1 52.2754 51.002)" fill="#2A2929"/>
+  <circle r="3" transform="matrix(-1 0 0 1 92 175)" fill="#2A2929"/>
+  <circle r="1.5" transform="matrix(-1 0 0 1 269.5 96.5)" fill="#2A2929"/>
+  <circle r="1.5" transform="matrix(-1 0 0 1 110.775 21.502)" fill="#2A2929"/>
+  <path d="M18.8991 68.4823C16.9988 70.4004 12.4916 72.9373 9.66566 67.7397C6.83972 62.5422 2.78538 63.9205 1.11144 65.2593" stroke="black" stroke-width="2"/>
+  <path d="M189.973 1.05229C191.151 2.65926 192.479 6.23774 188.364 7.69583C184.249 9.15393 184.784 12.2683 185.566 13.6432" stroke="black" stroke-width="2"/>
+  <path d="M215.116 165.366C213.492 166.52 209.895 167.796 208.497 163.66C207.098 159.524 203.977 160.014 202.591 160.776" stroke="black" stroke-width="2"/>
+  <path d="M63.301 76.3543L53.2283 67.8889L65.5959 63.3984L63.301 76.3543Z" fill="#7FD1B9"/>
+  <path d="M69.1713 64.6503L67.1785 75.9007L58.4318 68.5497L69.1713 64.6503Z" stroke="black"/>
+  <rect x="209.166" y="87" width="5.26466" height="5.26466" transform="rotate(78.8382 209.166 87)" fill="#FFE500"/>
+  <circle cx="211.212" cy="53.6287" r="3" transform="rotate(-15.8251 211.212 53.6287)" fill="#E98686"/>
+  <circle cx="209.704" cy="51.9764" r="2.5" transform="rotate(-15.8251 209.704 51.9764)" stroke="black"/>
+  <path d="M52.0971 17.908L62.8507 19.5304L56.0688 28.032L52.0971 17.908Z" fill="#FFE500"/>
+  <path d="M53.0364 28.5218L49.6972 20.0101L58.7381 21.3741L53.0364 28.5218Z" stroke="black"/>
+  <circle cx="98.2946" cy="43.0743" r="4.47923" transform="rotate(-15.8251 98.2946 43.0743)" fill="#54A2DB"/>
+  <circle cx="95.531" cy="41.5313" r="3.97923" transform="rotate(-15.8251 95.531 41.5313)" stroke="black"/>
+  <rect x="64.6738" y="150.52" width="8.62346" height="8.62346" transform="rotate(66.5152 64.6738 150.52)" fill="#FFE500"/>
+  <rect x="65.4067" y="148.658" width="7.62346" height="7.62346" transform="rotate(66.5152 65.4067 148.658)" stroke="black"/>
+  <rect x="152.486" y="7.42969" width="4.89175" height="4.89175" transform="rotate(66.5152 152.486 7.42969)" fill="#7FD1B9"/>
+  <rect x="152.557" y="5.65784" width="3.89175" height="3.89175" transform="rotate(66.5152 152.557 5.65784)" stroke="black"/>
+  <rect x="244.734" y="92.9785" width="5.99528" height="5.99528" transform="rotate(66.5152 244.734 92.9785)" fill="#54A2DB"/>
+  <rect x="244.879" y="90.6578" width="4.99528" height="4.99528" transform="rotate(66.5152 244.879 90.6578)" stroke="black"/>
+  <path d="M204.623 129.884L213.355 138.201L201.786 141.605L204.623 129.884Z" fill="#E98686"/>
+  <path d="M198.644 140.198L201.073 130.16L208.551 137.283L198.644 140.198Z" stroke="black"/>
+  <circle cx="169.53" cy="173.322" r="3.88047" transform="rotate(-15.8251 169.53 173.322)" fill="#7FD1B9"/>
+  <circle cx="166.792" cy="171.792" r="3.38047" transform="rotate(-15.8251 166.792 171.792)" stroke="black"/>
+</svg>

--- a/SwiftPackage/Sources/AssessmentModelUI/Resources/Images.xcassets/completion/completion.1.imageset/Contents.json
+++ b/SwiftPackage/Sources/AssessmentModelUI/Resources/Images.xcassets/completion/completion.1.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "completion_checkmark.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
+  }
+}

--- a/SwiftPackage/Sources/AssessmentModelUI/Resources/Images.xcassets/completion/completion.1.imageset/completion_checkmark.svg
+++ b/SwiftPackage/Sources/AssessmentModelUI/Resources/Images.xcassets/completion/completion.1.imageset/completion_checkmark.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg width="272" height="179" viewBox="0 0 272 179" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M121.275 110.958L134.647 124.002L160.275 99.002" stroke="#93CCF0" stroke-width="10"/>
+</svg>

--- a/SwiftPackage/Sources/AssessmentModelUI/Views/AssessmentView.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/Views/AssessmentView.swift
@@ -117,10 +117,10 @@ public struct AssessmentView : View {
             TitlePageView(step)
         }
         else if let step = state?.step as? CompletionStep {
-            CompletionView(step)
+            CompletionStepView(step)
         }
         else if let nodeState = state as? ContentNodeState {
-            InstructionView(nodeState)
+            InstructionStepView(nodeState)
         }
         else {
             debugStepView(state!)

--- a/SwiftPackage/Sources/AssessmentModelUI/Views/Components/CompositedImage.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/Views/Components/CompositedImage.swift
@@ -38,20 +38,36 @@ public struct CompositedImage: View {
     let imageName: String
     let layerCount: Int
     let bundle: Bundle?
+    let isResizable: Bool
     
-    public init(_ imageName: String, bundle: Bundle? = nil, layers: Int = 2) {
+    public init(_ imageName: String, bundle: Bundle? = nil, layers: Int = 2, isResizable: Bool = false) {
         self.imageName = imageName
         self.layerCount = layers
         self.bundle = bundle
+        self.isResizable = isResizable
     }
     
     public var body: some View {
         ZStack {
             ForEach(0 ..< layerCount, id:\.self) { layer in
-                Image("\(imageName).\(layer)", bundle: bundle)
+                Image(decorative: "\(imageName).\(layer)", bundle: bundle)
+                    .fillFit(isResizable)
             }
         }
         .foregroundColor(surveyTint)
+    }
+}
+
+extension Image {
+    
+    @ViewBuilder
+    func fillFit(_ isResized: Bool) -> some View {
+        if isResized {
+            self.resizable().scaledToFit()
+        }
+        else {
+            self
+        }
     }
 }
 
@@ -61,6 +77,7 @@ struct LayeredImageView_Previews: PreviewProvider {
             CompositedImage("survey", bundle: .module, layers: 4)
             CompositedImage("survey", bundle: .module, layers: 4)
                 .surveyTintColor(.red)
+            CompositedImage("survey", bundle: .module, layers: 4, isResizable: true)
         }
     }
 }

--- a/SwiftPackage/Sources/AssessmentModelUI/Views/Components/ContentImage.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/Views/Components/ContentImage.swift
@@ -52,6 +52,7 @@ public struct ContentImage : View, Identifiable {
     ///   - imageInfo: The image info to use to get the resource.
     ///   - label: The accessibility label.
     public init(_ imageInfo: ImageInfo, label: Text? = nil) {
+        let label = label ?? imageInfo.label.map { Text($0) }
         if let iconKey = (imageInfo as? SageResourceImage)?.name {
             self.init(icon: iconKey, label: label)
         }

--- a/SwiftPackage/Sources/AssessmentModelUI/Views/Steps/instruction/CompletionStepView.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/Views/Steps/instruction/CompletionStepView.swift
@@ -1,5 +1,5 @@
 //
-//  CompletionView.swift
+//  CompletionStepView.swift
 //
 //
 //  Copyright © 2022 Sage Bionetworks. All rights reserved.
@@ -35,7 +35,47 @@ import SwiftUI
 import AssessmentModel
 import SharedMobileUI
 
-struct CompletionView: View {
+public struct CompletionView : View {
+    @SwiftUI.Environment(\.verticalPadding) var verticalPadding: CGFloat
+    @SwiftUI.Environment(\.horizontalPadding) var horizontalPadding: CGFloat
+    @State var imageHeight: CGFloat = 0.0
+    
+    let title: Text
+    let detail: Text
+    
+    public init(title: Text, detail: Text) {
+        self.title = title
+        self.detail = detail
+    }
+    
+    public var body: some View {
+        ZStack(alignment: .top) {
+            VStack(spacing: 0) {
+                Color.clear
+                    .frame(height: imageHeight * 2.0 / 3.0)
+                VStack(spacing: verticalPadding) {
+                    title
+                        .font(.stepTitle)
+                    detail
+                        .font(.stepDetail)
+                }
+                .padding(.horizontal, horizontalPadding)
+                .padding(.top, imageHeight / 3.0 + verticalPadding)
+                .padding(.bottom, 32)
+                .foregroundColor(.textForeground)
+                .background(Color.sageWhite
+                                .shadow(color: .hex2A2A2A.opacity(0.1), radius: 3, x: 1, y: 1))
+                .padding(.horizontal, horizontalPadding)
+            }
+            
+            CompositedImage("completion", bundle: .module, layers: 2, isResizable: true)
+                .padding(.horizontal)
+                .heightReader(height: $imageHeight)
+        }
+    }
+}
+
+public struct CompletionStepView : View {
     @EnvironmentObject var pagedNavigation: PagedNavigationViewModel
     let step: CompletionStep
     
@@ -45,30 +85,39 @@ struct CompletionView: View {
     
     public var body: some View {
         VStack {
-            ContentNodeView(step, alignment: .leading)
+            Spacer()
+            CompletionView(title: title(), detail: detail())
+            Spacer()
             if pagedNavigation.backEnabled {
                 SurveyNavigationView()
             }
             else {
                 ForwardButton {
                     pagedNavigation.forwardButtonText ??
-                    Text("Done", bundle: .module)
+                    Text("Exit", bundle: .module)
                 }
             }
         }
+        .fullscreenBackground(.lightSurveyBackground)
+    }
+    
+    func title() -> Text {
+        step.title.map { Text($0) } ??
+        Text("Well done!", bundle: .module)
+    }
+    
+    func detail() -> Text {
+        step.detail.map { Text($0) } ??
+        Text("Thank you for being part of our study.", bundle: .module)
     }
 }
 
 struct CompletionView_Previews: PreviewProvider {
     static var previews: some View {
-        CompletionView(example)
+        CompletionStepView(exampleA)
             .environmentObject(PagedNavigationViewModel(pageCount: 5, currentIndex: 0))
-            .environmentObject(AssessmentState(AssessmentObject(previewStep: example)))
+            .environmentObject(AssessmentState(AssessmentObject(previewStep: exampleA)))
     }
 }
 
-fileprivate let example = CompletionStepObject(
-    identifier: "example",
-    title: "Example Survey A",
-    detail: "You will be shown a series of example questions. This survey has no additional instructions.",
-    imageInfo: SageResourceImage(.survey))
+fileprivate let exampleA = CompletionStepObject(identifier: "exampleA")

--- a/SwiftPackage/Sources/AssessmentModelUI/Views/Steps/instruction/InstructionStepView.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/Views/Steps/instruction/InstructionStepView.swift
@@ -1,5 +1,5 @@
 //
-//  InstructionView.swift
+//  InstructionStepView.swift
 //
 //
 //  Copyright © 2022 Sage Bionetworks. All rights reserved.
@@ -35,7 +35,7 @@ import SwiftUI
 import AssessmentModel
 import SharedMobileUI
 
-struct InstructionView: View {
+public struct InstructionStepView: View {
     @ObservedObject var nodeState: ContentNodeState
     
     public init(_ nodeState: ContentNodeState) {
@@ -53,7 +53,7 @@ struct InstructionView: View {
 
 struct InstructionView_Previews: PreviewProvider {
     static var previews: some View {
-        InstructionView(InstructionState(example, parentId: nil))
+        InstructionStepView(InstructionState(example, parentId: nil))
             .environmentObject(PagedNavigationViewModel(pageCount: 5, currentIndex: 0))
             .environmentObject(AssessmentState(AssessmentObject(previewStep: example)))
     }

--- a/iosAppPreview/iosAppPreview.xcodeproj/project.pbxproj
+++ b/iosAppPreview/iosAppPreview.xcodeproj/project.pbxproj
@@ -26,8 +26,8 @@
 		FFC14E25280B6A4800B17551 /* CompositedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC14E24280B6A4800B17551 /* CompositedImage.swift */; };
 		FFC14E27280F8A9300B17551 /* TitlePageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC14E26280F8A9300B17551 /* TitlePageView.swift */; };
 		FFC14E292810905000B17551 /* ForwardButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC14E282810905000B17551 /* ForwardButton.swift */; };
-		FFC14E2B2811DD0500B17551 /* InstructionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC14E2A2811DD0500B17551 /* InstructionView.swift */; };
-		FFC14E2D2811E31500B17551 /* CompletionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC14E2C2811E31500B17551 /* CompletionView.swift */; };
+		FFC14E2B2811DD0500B17551 /* InstructionStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC14E2A2811DD0500B17551 /* InstructionStepView.swift */; };
+		FFC14E2D2811E31500B17551 /* CompletionStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC14E2C2811E31500B17551 /* CompletionStepView.swift */; };
 		FFC14E612817091E00B17551 /* IntegerQuestionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC14E602817091E00B17551 /* IntegerQuestionViewModel.swift */; };
 		FFC14E632817113600B17551 /* ContentNodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC14E622817113600B17551 /* ContentNodeView.swift */; };
 		FFC14E67281717CD00B17551 /* LikertScaleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC14E66281717CD00B17551 /* LikertScaleView.swift */; };
@@ -51,6 +51,8 @@
 		FFEB558B2829B9AE007C5572 /* DurationQuestionStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB558A2829B9AD007C5572 /* DurationQuestionStepView.swift */; };
 		FFEB558D2829CCC2007C5572 /* TimeQuestionStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB558C2829CCC2007C5572 /* TimeQuestionStepView.swift */; };
 		FFEB558F2829CD0E007C5572 /* TimeQuestionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB558E2829CD0E007C5572 /* TimeQuestionViewModel.swift */; };
+		FFF12AE5284A684D00A0CD76 /* ContentImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF12AE3284A684D00A0CD76 /* ContentImage.swift */; };
+		FFF12AE6284A684D00A0CD76 /* TopBarProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF12AE4284A684D00A0CD76 /* TopBarProgressView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -73,8 +75,8 @@
 		FFC14E24280B6A4800B17551 /* CompositedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompositedImage.swift; sourceTree = "<group>"; };
 		FFC14E26280F8A9300B17551 /* TitlePageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlePageView.swift; sourceTree = "<group>"; };
 		FFC14E282810905000B17551 /* ForwardButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForwardButton.swift; sourceTree = "<group>"; };
-		FFC14E2A2811DD0500B17551 /* InstructionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructionView.swift; sourceTree = "<group>"; };
-		FFC14E2C2811E31500B17551 /* CompletionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionView.swift; sourceTree = "<group>"; };
+		FFC14E2A2811DD0500B17551 /* InstructionStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructionStepView.swift; sourceTree = "<group>"; };
+		FFC14E2C2811E31500B17551 /* CompletionStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionStepView.swift; sourceTree = "<group>"; };
 		FFC14E602817091E00B17551 /* IntegerQuestionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerQuestionViewModel.swift; sourceTree = "<group>"; };
 		FFC14E622817113600B17551 /* ContentNodeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentNodeView.swift; sourceTree = "<group>"; };
 		FFC14E66281717CD00B17551 /* LikertScaleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikertScaleView.swift; sourceTree = "<group>"; };
@@ -99,6 +101,8 @@
 		FFEB558A2829B9AD007C5572 /* DurationQuestionStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DurationQuestionStepView.swift; sourceTree = "<group>"; };
 		FFEB558C2829CCC2007C5572 /* TimeQuestionStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeQuestionStepView.swift; sourceTree = "<group>"; };
 		FFEB558E2829CD0E007C5572 /* TimeQuestionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeQuestionViewModel.swift; sourceTree = "<group>"; };
+		FFF12AE3284A684D00A0CD76 /* ContentImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentImage.swift; sourceTree = "<group>"; };
+		FFF12AE4284A684D00A0CD76 /* TopBarProgressView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopBarProgressView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -118,8 +122,8 @@
 			isa = PBXGroup;
 			children = (
 				FFC14E26280F8A9300B17551 /* TitlePageView.swift */,
-				FFC14E2C2811E31500B17551 /* CompletionView.swift */,
-				FFC14E2A2811DD0500B17551 /* InstructionView.swift */,
+				FFC14E2C2811E31500B17551 /* CompletionStepView.swift */,
+				FFC14E2A2811DD0500B17551 /* InstructionStepView.swift */,
 			);
 			path = instruction;
 			sourceTree = "<group>";
@@ -253,6 +257,8 @@
 		FFCB534527F6A78900BED4E2 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				FFF12AE3284A684D00A0CD76 /* ContentImage.swift */,
+				FFF12AE4284A684D00A0CD76 /* TopBarProgressView.swift */,
 				FFC14E24280B6A4800B17551 /* CompositedImage.swift */,
 				FFC14E622817113600B17551 /* ContentNodeView.swift */,
 				FFAF7C532808AC1B004B5670 /* ExitButton.swift */,
@@ -374,7 +380,7 @@
 				FF629A9F27FA6A6B0082EDD7 /* QuestionStepScrollView.swift in Sources */,
 				FFC14E25280B6A4800B17551 /* CompositedImage.swift in Sources */,
 				FFCB530B27F6A4F800BED4E2 /* iosAppPreviewApp.swift in Sources */,
-				FFC14E2D2811E31500B17551 /* CompletionView.swift in Sources */,
+				FFC14E2D2811E31500B17551 /* CompletionStepView.swift in Sources */,
 				FFCB534E27F6A78900BED4E2 /* MultilineTextField.swift in Sources */,
 				FFEB558B2829B9AE007C5572 /* DurationQuestionStepView.swift in Sources */,
 				FF629AA527FB63700082EDD7 /* AssessmentViewModel.swift in Sources */,
@@ -389,11 +395,13 @@
 				FFCB534D27F6A78900BED4E2 /* KeyboardOptions+SwiftUI.swift in Sources */,
 				FFCB534B27F6A78900BED4E2 /* KeyboardObserver.swift in Sources */,
 				FFCB534A27F6A78900BED4E2 /* ChoiceQuestionViewModel.swift in Sources */,
+				FFF12AE5284A684D00A0CD76 /* ContentImage.swift in Sources */,
 				FFDDD56827F7A4AE00B40F22 /* ViewHeightReader.swift in Sources */,
+				FFF12AE6284A684D00A0CD76 /* TopBarProgressView.swift in Sources */,
 				FFCB535A27F6B60B00BED4E2 /* NodeState.swift in Sources */,
 				FFC14E67281717CD00B17551 /* LikertScaleView.swift in Sources */,
 				FF015E7C281891DF004BD345 /* IntegerQuestionStepView.swift in Sources */,
-				FFC14E2B2811DD0500B17551 /* InstructionView.swift in Sources */,
+				FFC14E2B2811DD0500B17551 /* InstructionStepView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
We're going on the assumption that the [Survey Builder UI](https://www.figma.com/file/edCHqzwDQLgnBUXj7KoNl3/Surveys_ResearcherUI?node-id=693%3A96363) has more a accurate design that the [Participant UI](https://www.figma.com/file/3D66BVG34tTYQ1D2ziUAcu/Surveys_Participant-UI?node-id=0%3A1) which currently does not have a completion screen or instruction screen that are different from the title page.