### PR TITLE
Fix repeat survey questions

### DIFF
--- a/SwiftPackage/Sources/AssessmentModelUI/Views/AssessmentView.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/Views/AssessmentView.swift
@@ -168,6 +168,7 @@ struct AssessmentView_Previews: PreviewProvider {
 public var previewExamples: [AssessmentObject] = [
     surveyA,
     surveyB,
+    surveyC,
 ]
 
 let surveyA = AssessmentObject(identifier: "surveyA",
@@ -279,3 +280,102 @@ fileprivate let sectionB2Children: [Node] = [
 ]
 
 
+let surveyCJson = """
+{
+  "identifier": "daily",
+  "type": "assessment",
+  "interruptionHandling": {
+    "reviewIdentifier": null
+  },
+  "steps": [
+    {
+      "type": "simpleQuestion",
+      "identifier": "energy",
+      "title": "Please rate your energy level right now.",
+      "detail": "0 being very low, 5 being your average, and 10 being very high",
+      "uiHint": "slider",
+      "inputItem": {
+        "type": "integer",
+        "formatOptions": {
+          "maximumLabel": "Very high",
+          "maximumValue": 10,
+          "minimumLabel": "Very low",
+          "minimumValue": 0
+        }
+      }
+    },
+    {
+      "type": "simpleQuestion",
+      "identifier": "mood",
+      "title": "Please rate your mood right now.",
+      "detail": "0 being very low, 5 being your average, and 10 being very high",
+      "uiHint": "slider",
+      "inputItem": {
+        "type": "integer",
+        "formatOptions": {
+          "maximumLabel": "Very high",
+          "maximumValue": 10,
+          "minimumLabel": "Very low",
+          "minimumValue": 0
+        }
+      }
+    },
+    {
+      "type": "simpleQuestion",
+      "identifier": "thoughts",
+      "title": "How fast are your thoughts right now?",
+      "detail": "0 being very slow, 5 being your average, and 10 being very fast",
+      "uiHint": "slider",
+      "inputItem": {
+        "type": "integer",
+        "formatOptions": {
+          "maximumLabel": "Very fast",
+          "maximumValue": 10,
+          "minimumLabel": "Very slow",
+          "minimumValue": 0
+        }
+      }
+    },
+    {
+      "type": "simpleQuestion",
+      "identifier": "impulsiveness",
+      "title": "How impulsive are you feeling right now?",
+      "detail": "0 being not at all, 5 being your average, and 10 being very much",
+      "uiHint": "slider",
+      "inputItem": {
+        "type": "integer",
+        "formatOptions": {
+          "maximumLabel": "Very much",
+          "maximumValue": 10,
+          "minimumLabel": "Not at all",
+          "minimumValue": 0
+        }
+      }
+    },
+    {
+      "type": "simpleQuestion",
+      "identifier": "attention",
+      "title": "How well are you able to focus right now?",
+      "detail": "0 being not at all, 5 being your average, and 10 being very well",
+      "uiHint": "slider",
+      "inputItem": {
+        "type": "integer",
+        "formatOptions": {
+          "maximumLabel": "Very well",
+          "maximumValue": 10,
+          "minimumLabel": "Not at all",
+          "minimumValue": 0
+        }
+      },
+      "actions": {
+        "goForward": {
+          "buttonTitle": "Submit",
+          "type": "default"
+        }
+      }
+    }
+  ]
+}
+""".data(using: .utf8)!
+
+let surveyC = try! AssessmentFactory().createJSONDecoder().decode(AssessmentObject.self, from: surveyCJson)

--- a/SwiftPackage/Sources/AssessmentModelUI/Views/Steps/question/ChoiceQuestionStepView.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/Views/Steps/question/ChoiceQuestionStepView.swift
@@ -47,7 +47,6 @@ public struct ChoiceQuestionStepView : View {
         QuestionStepScrollView {
             ChoiceQuestionView()
         }
-        .id("\(type(of: self)):\(questionState.id)")   // Give the view a unique id to force refresh
         .environmentObject(questionState)
         .fullscreenBackground(.lightSurveyBackground)
     }

--- a/SwiftPackage/Sources/AssessmentModelUI/Views/Steps/question/DurationQuestionStepView.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/Views/Steps/question/DurationQuestionStepView.swift
@@ -65,7 +65,6 @@ public struct DurationQuestionStepView: View {
             }
             .padding(.horizontal, horizontalPadding)
         }
-        .id("\(type(of: self)):\(questionState.id)")   // Give the view a unique id to force refresh
         .environmentObject(questionState)
         .fullscreenBackground(.darkSurveyBackground, backButtonStyle: .white)
         .onAppear {

--- a/SwiftPackage/Sources/AssessmentModelUI/Views/Steps/question/IntegerQuestionStepView.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/Views/Steps/question/IntegerQuestionStepView.swift
@@ -51,7 +51,6 @@ public struct IntegerQuestionStepView : View {
                 IntegerTextField(viewModel: model)
             }
         }
-        .id("\(type(of: self)):\(questionState.id)")   // Give the view a unique id to force refresh
         .environmentObject(questionState)
         .fullscreenBackground(.darkSurveyBackground, backButtonStyle: .white)
         .onAppear {

--- a/SwiftPackage/Sources/AssessmentModelUI/Views/Steps/question/TextEntryQuestionStepView.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/Views/Steps/question/TextEntryQuestionStepView.swift
@@ -50,7 +50,6 @@ public struct TextEntryQuestionStepView: View {
                 TextViewWrapper(viewModel: model)
             }
         }
-        .id("\(type(of: self)):\(questionState.id)")   // Give the view a unique id to force refresh
         .environmentObject(questionState)
         .innerSpacing(6)
         .fullscreenBackground(.darkSurveyBackground, backButtonStyle: .white)

--- a/SwiftPackage/Sources/AssessmentModelUI/Views/Steps/question/TimeQuestionStepView.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/Views/Steps/question/TimeQuestionStepView.swift
@@ -58,7 +58,6 @@ public struct TimeQuestionStepView: View {
                     #endif
             }
         }
-        .id("\(type(of: self)):\(questionState.id)")   // Give the view a unique id to force refresh
         .environmentObject(questionState)
         .fullscreenBackground(.darkSurveyBackground, backButtonStyle: .white)
         .onAppear {

--- a/iosApp/SurveyExamples/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/iosApp/SurveyExamples/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -6,8 +6,8 @@
         "components" : {
           "alpha" : "1.000",
           "blue" : "0xFF",
-          "green" : "0xD6",
-          "red" : "0x8F"
+          "green" : "0x90",
+          "red" : "0x00"
         }
       },
       "idiom" : "universal"

--- a/iosApp/SurveyExamples/ContentView.swift
+++ b/iosApp/SurveyExamples/ContentView.swift
@@ -73,6 +73,7 @@ struct ContentView: View {
                 .onChange(of: state.status) { newValue in
                     print("assessment status = \(newValue)")
                     guard newValue >= .finished else { return }
+                    print("\(try! state.result.jsonDictionary())")
                     // In a real use-case this is where you might save and upload data
                     viewModel.isPresented = false
                     viewModel.current = nil


### PR DESCRIPTION
So... SwiftUI is fun. Apparently it wasn't recognizing that the identifier means that it's a new view if the view being rendered doesn't change "type" (ie. series of slider questions, for example). *sigh*