### PR TITLE
Add moduleInfo polymorphic serializers module to the default serializers module.

### DIFF
--- a/assessmentModel/src/commonMain/kotlin/serialization/Serialization.kt
+++ b/assessmentModel/src/commonMain/kotlin/serialization/Serialization.kt
@@ -17,6 +17,7 @@ object Serialization {
                 imageSerializersModule +
                 nodeSerializersModule +
                 resultSerializersModule +
+                moduleInfoSerializersModule +
                 SerializersModule {}    // Marker for the end of the list. Used to make github read more cleanly.
     }
     object JsonCoder {


### PR DESCRIPTION
Default for EmbeddedJsonAssessmentRegistryProvider now uses this, so it needs the moduleInfo serializers.