### PR TITLE
Update Swift Package to support JsonModel “1.6.0”..<“3.0.0”

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
         "state": {
           "branch": null,
-          "revision": "ddde0196c6e85b9adcfc3c5436b31b26f033f386",
-          "version": "1.4.7"
+          "revision": "cf13a8af6b09c25605f340150bb6392ea9d3c0f8",
+          "version": "2.0.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Sage-Bionetworks/MobilePassiveData-SDK.git",
         "state": {
           "branch": null,
-          "revision": "9c48602422ff2de9404112b9f2ed98c0a9ca2c44",
-          "version": "1.2.4"
+          "revision": "5c1b98eedde37fd6a898798c031f5e7d863404b3",
+          "version": "1.4.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -22,13 +22,13 @@ let package = Package(
     dependencies: [
         .package(name: "JsonModel",
                  url: "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
-                 from: "1.4.7"),
+                 "1.6.0"..<"3.0.0"),
         .package(name: "SharedMobileUI",
                  url: "https://github.com/Sage-Bionetworks/SharedMobileUI-AppleOS.git",
                  from: "0.17.0"),
         .package(name: "MobilePassiveData",
                  url: "https://github.com/Sage-Bionetworks/MobilePassiveData-SDK.git",
-                 from: "1.2.4"),
+                 from: "1.4.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/SwiftPackage/Sources/AssessmentModel/Assessment/Assessment.swift
+++ b/SwiftPackage/Sources/AssessmentModel/Assessment/Assessment.swift
@@ -33,6 +33,7 @@
 
 import Foundation
 import JsonModel
+import ResultModel
 import MobilePassiveData
 
 open class AbstractNodeContainerObject : AbstractContentNodeObject, AsyncActionContainer {

--- a/SwiftPackage/Sources/AssessmentModel/Assessment/AssessmentInterface.swift
+++ b/SwiftPackage/Sources/AssessmentModel/Assessment/AssessmentInterface.swift
@@ -33,6 +33,7 @@
 
 import Foundation
 import JsonModel
+import ResultModel
 import MobilePassiveData
 
 /// A result map element is an element in the ``Assessment`` model that defines the expectations for a

--- a/SwiftPackage/Sources/AssessmentModel/Assessment/NodeSerializer.swift
+++ b/SwiftPackage/Sources/AssessmentModel/Assessment/NodeSerializer.swift
@@ -33,6 +33,7 @@
 
 import Foundation
 import JsonModel
+import ResultModel
 
 /// `SerializableNode` is the base implementation for `Node` that is serialized using
 /// the `Codable` protocol and the polymorphic serialization defined by this framework.

--- a/SwiftPackage/Sources/AssessmentModel/Assessment/Question/ChoiceQuestion.swift
+++ b/SwiftPackage/Sources/AssessmentModel/Assessment/Question/ChoiceQuestion.swift
@@ -33,6 +33,7 @@
 
 import Foundation
 import JsonModel
+import ResultModel
 
 public protocol ChoiceInputItem : InputItem, ChoiceOption {
 }

--- a/SwiftPackage/Sources/AssessmentModel/Assessment/Question/Question.swift
+++ b/SwiftPackage/Sources/AssessmentModel/Assessment/Question/Question.swift
@@ -32,6 +32,7 @@
 
 import Foundation
 import JsonModel
+import ResultModel
 
 /// A ``Question`` can be an input of a form or it might be a stand-alone question. It represents
 /// something that, when composited, will result in a single answer. It may compose input fields to do

--- a/SwiftPackage/Sources/AssessmentModel/Assessment/Question/SimpleQuestion.swift
+++ b/SwiftPackage/Sources/AssessmentModel/Assessment/Question/SimpleQuestion.swift
@@ -33,6 +33,7 @@
 
 import Foundation
 import JsonModel
+import ResultModel
 
 /// A simple question can be represented as text entry of a single value. The UI/UX for presenting the question
 /// might not use a text field, based on the ``QuestionUIHint`` and the requirements of the application

--- a/SwiftPackage/Sources/AssessmentModel/Assessment/Question/TextInputItem.swift
+++ b/SwiftPackage/Sources/AssessmentModel/Assessment/Question/TextInputItem.swift
@@ -33,6 +33,7 @@
 
 import Foundation
 import JsonModel
+import ResultModel
 
 /// An ``TextInputItem`` describes input entry that is freeform with ranges and validation. Typically, this is
 /// presented as a text field, but depending upon the requirements of the survey designer, it may use a slider,

--- a/SwiftPackage/Sources/AssessmentModel/AssessmentFactory.swift
+++ b/SwiftPackage/Sources/AssessmentModel/AssessmentFactory.swift
@@ -33,6 +33,7 @@
 
 import Foundation
 import JsonModel
+import ResultModel
 import MobilePassiveData
 
 /// A lightweight protocol for copying objects with a new identifier.

--- a/SwiftPackage/Sources/AssessmentModel/Navigation/Navigator.swift
+++ b/SwiftPackage/Sources/AssessmentModel/Navigation/Navigator.swift
@@ -33,6 +33,7 @@
 
 import Foundation
 import JsonModel
+import ResultModel
 
 /// The navigation state is a means to allow circular references where the navigator may require state information
 /// from the state machine to initialize.

--- a/SwiftPackage/Sources/AssessmentModel/Navigation/NodeNavigator.swift
+++ b/SwiftPackage/Sources/AssessmentModel/Navigation/NodeNavigator.swift
@@ -33,6 +33,7 @@
 
 import Foundation
 import JsonModel
+import ResultModel
 
 /// The navigation rule is used to allow the assessment navigator to check if a node has a navigation rule and
 /// apply as necessary.

--- a/SwiftPackage/Sources/AssessmentModel/Navigation/SurveyRule.swift
+++ b/SwiftPackage/Sources/AssessmentModel/Navigation/SurveyRule.swift
@@ -30,8 +30,9 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-import JsonModel
 import Foundation
+import JsonModel
+import ResultModel
 
 /// Defines an evaluation rule and returns a step identifier if appropriate.
 public protocol SurveyRule {

--- a/SwiftPackage/Sources/AssessmentModelUI/ViewModels/AssessmentViewModel.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/ViewModels/AssessmentViewModel.swift
@@ -35,6 +35,7 @@ import SwiftUI
 import SharedMobileUI
 import AssessmentModel
 import JsonModel
+import ResultModel
 
 
 open class AssessmentViewModel : ObservableObject, NavigationState {

--- a/SwiftPackage/Sources/AssessmentModelUI/ViewModels/DurationQuestionViewModel.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/ViewModels/DurationQuestionViewModel.swift
@@ -34,6 +34,7 @@
 import SwiftUI
 import AssessmentModel
 import JsonModel
+import ResultModel
 
 class DurationQuestionViewModel : ObservableObject, TextInputViewModelDelegate {
     

--- a/SwiftPackage/Sources/AssessmentModelUI/ViewModels/NodeState.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/ViewModels/NodeState.swift
@@ -34,6 +34,7 @@
 import SwiftUI
 import AssessmentModel
 import JsonModel
+import ResultModel
 
 /// The state objects are all simple objects without any business or navigation logic. This is done because
 /// SwiftUI  @EnvironmentObject observables have to be castable using NSClassFromString so the environment

--- a/SwiftPackage/Sources/AssessmentModelUI/Views/AssessmentView.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/Views/AssessmentView.swift
@@ -35,6 +35,7 @@ import SwiftUI
 import SharedMobileUI
 import AssessmentModel
 import JsonModel
+import ResultModel
 
 /// This protocol extends the model and views that are used to display an assessment using views that are not
 /// defined within this library.

--- a/SwiftPackage/Sources/AssessmentModelUI/Views/Steps/question/LikertScaleView.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/Views/Steps/question/LikertScaleView.swift
@@ -34,6 +34,7 @@
 import SwiftUI
 import AssessmentModel
 import JsonModel
+import ResultModel
 import SharedMobileUI
 
 fileprivate let dotSize: CGFloat = 30

--- a/SwiftPackage/Sources/AssessmentModelUI/Views/Steps/question/SlidingScaleView.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/Views/Steps/question/SlidingScaleView.swift
@@ -34,6 +34,7 @@
 import SwiftUI
 import AssessmentModel
 import JsonModel
+import ResultModel
 import SharedMobileUI
 
 struct SlidingScaleView : View {

--- a/SwiftPackage/Tests/AssessmentModelTests/AssessmentFactoryTests.swift
+++ b/SwiftPackage/Tests/AssessmentModelTests/AssessmentFactoryTests.swift
@@ -32,6 +32,7 @@
 
 import XCTest
 @testable import JsonModel
+@testable import ResultModel
 @testable import AssessmentModel
 
 class AssessmentModelTests: XCTestCase {

--- a/SwiftPackage/Tests/AssessmentModelTests/AssessmentTests/CodingTests/CodableNodeTests.swift
+++ b/SwiftPackage/Tests/AssessmentModelTests/AssessmentTests/CodingTests/CodableNodeTests.swift
@@ -33,6 +33,7 @@
 import XCTest
 @testable import AssessmentModel
 import JsonModel
+import ResultModel
 
 class CodableQuestionTests: XCTestCase {
     

--- a/SwiftPackage/Tests/AssessmentModelTests/AssessmentTests/NavigationTests/NodeNavigatorTests.swift
+++ b/SwiftPackage/Tests/AssessmentModelTests/AssessmentTests/NavigationTests/NodeNavigatorTests.swift
@@ -35,6 +35,7 @@ import Foundation
 
 import XCTest
 import JsonModel
+import ResultModel
 @testable import AssessmentModel
 
 class NodeNavigatorTests: XCTestCase {

--- a/SwiftPackage/Tests/AssessmentModelTests/AssessmentTests/NavigationTests/SurveyRuleTests.swift
+++ b/SwiftPackage/Tests/AssessmentModelTests/AssessmentTests/NavigationTests/SurveyRuleTests.swift
@@ -34,6 +34,7 @@ import Foundation
 
 import XCTest
 import JsonModel
+import ResultModel
 @testable import AssessmentModel
 
 class SurveyRuleTests: XCTestCase {

--- a/SwiftPackage/Tests/AssessmentModelUITests/AssessmentNavigationTests.swift
+++ b/SwiftPackage/Tests/AssessmentModelUITests/AssessmentNavigationTests.swift
@@ -34,6 +34,7 @@
 
 import XCTest
 import JsonModel
+import ResultModel
 @testable import AssessmentModel
 @testable import AssessmentModelUI
 

--- a/SwiftPackage/Tests/AssessmentModelUITests/ChoiceQuestionViewModelTests.swift
+++ b/SwiftPackage/Tests/AssessmentModelUITests/ChoiceQuestionViewModelTests.swift
@@ -35,6 +35,7 @@ import Foundation
 @testable import AssessmentModelUI
 @testable import AssessmentModel
 import JsonModel
+import ResultModel
 import XCTest
 
 class ChoiceQuestionViewModelTests: XCTestCase {

--- a/SwiftPackage/Tests/AssessmentModelUITests/DurationQuestionViewModelTests.swift
+++ b/SwiftPackage/Tests/AssessmentModelUITests/DurationQuestionViewModelTests.swift
@@ -35,6 +35,7 @@ import Foundation
 @testable import AssessmentModelUI
 @testable import AssessmentModel
 import JsonModel
+import ResultModel
 import XCTest
 
 class DurationQuestionViewModelTests: XCTestCase {

--- a/SwiftPackage/Tests/AssessmentModelUITests/LikertScaleViewModelTests.swift
+++ b/SwiftPackage/Tests/AssessmentModelUITests/LikertScaleViewModelTests.swift
@@ -35,6 +35,7 @@ import Foundation
 @testable import AssessmentModelUI
 @testable import AssessmentModel
 import JsonModel
+import ResultModel
 import XCTest
 
 class LikertScaleViewModelTests: XCTestCase {

--- a/SwiftPackage/Tests/AssessmentModelUITests/SlidingScaleViewModelTests.swift
+++ b/SwiftPackage/Tests/AssessmentModelUITests/SlidingScaleViewModelTests.swift
@@ -35,6 +35,7 @@ import Foundation
 @testable import AssessmentModelUI
 @testable import AssessmentModel
 import JsonModel
+import ResultModel
 import XCTest
 
 class SlidingScaleViewModelTests: XCTestCase {

--- a/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -58,6 +58,16 @@
                ReferencedContainer = "container:iosApp.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AssessmentModelUITests"
+               BuildableName = "AssessmentModelUITests"
+               BlueprintName = "AssessmentModelUITests"
+               ReferencedContainer = "container:..">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/iosApp/iosAppTests/KMMSerializationTests.swift
+++ b/iosApp/iosAppTests/KMMSerializationTests.swift
@@ -36,7 +36,7 @@ import XCTest
 import JsonModel
 import KotlinModel
 
-class KMMSerializationTests: XCTestCase {
+class KMMSerializationTests: ResultSerializationTestCase {
     
     func testSurveyACodable() {
         let factory = AssessmentFactory()
@@ -147,7 +147,6 @@ class KMMSerializationTests: XCTestCase {
     func testResultCodable() {
         let factory = AssessmentFactory()
         let encoder = factory.createJSONEncoder()
-        let decoder = factory.createJSONDecoder()
 
         do {
             let json = try encoder.encode(swiftAssessmentResult)
@@ -166,47 +165,12 @@ class KMMSerializationTests: XCTestCase {
             let kmmEncoder = KotlinModel.ResultEncoder(result: kmmAssessmentResult)
             let kmmJsonString = try kmmEncoder.encodeObject()
             let kmmJson = kmmJsonString.data(using: .utf8)!
-            let decodedResult = try decoder.decode(AssessmentResultObject.self, from: kmmJson)
-            
-            checkResults(swiftResult: swiftAssessmentResult, decodedResult: decodedResult)
+            try checkAssessmentResult(from: kmmJson)
 
         } catch {
             XCTFail("Failed to encode or decode the assessment: \(error)")
         }
     }
     
-    func checkResults(swiftResult: JsonModel.ResultData, decodedResult: JsonModel.ResultData) {
-        XCTAssertEqual(swiftResult.typeName, decodedResult.typeName, "\(swiftResult.identifier)")
-        XCTAssertEqual(swiftResult.identifier, decodedResult.identifier, "\(swiftResult.identifier)")
-        XCTAssertEqual(swiftResult.startDate.timeIntervalSinceReferenceDate, decodedResult.startDate.timeIntervalSinceReferenceDate, accuracy: 0.1, "\(swiftResult.identifier)")
-        XCTAssertEqual(swiftResult.endDate.timeIntervalSinceReferenceDate, decodedResult.endDate.timeIntervalSinceReferenceDate, accuracy: 0.1, "\(swiftResult.identifier)")
-        
-        if let answerResult = swiftResult as? JsonModel.AnswerResultObject {
-            if let decoded = decodedResult as? JsonModel.AnswerResultObject {
-                XCTAssertEqual(answerResult.questionText, decoded.questionText, "\(swiftResult.identifier)")
-                XCTAssertEqual(answerResult.questionData, decoded.questionData, "\(swiftResult.identifier)")
-                XCTAssertEqual(answerResult.jsonValue, decoded.jsonValue, "\(swiftResult.identifier)")
-                XCTAssertEqual(answerResult.jsonAnswerType?.typeName, decoded.jsonAnswerType?.typeName, "\(swiftResult.identifier)")
-            }
-            else {
-                XCTFail("Failed to decode the correct type. expected=\(swiftResult), actual=\(decodedResult)")
-            }
-        }
-        else if let branchResult = swiftResult as? JsonModel.BranchNodeResult {
-            if let decoded = decodedResult as? JsonModel.BranchNodeResult {
-                branchResult.stepHistory.forEach { childResult in
-                    if let decodedChild = decoded.stepHistory.first(where: { $0.identifier == childResult.identifier }) {
-                        checkResults(swiftResult: childResult, decodedResult: decodedChild)
-                    }
-                    else {
-                        XCTFail("Failed to decode the matching child. expected=\(childResult)")
-                    }
-                }
-            }
-            else {
-                XCTFail("Failed to decode the correct type. expected=\(swiftResult), actual=\(decodedResult)")
-            }
-        }
-    }
 }
 

--- a/iosWorkspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosWorkspace.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Sage-Bionetworks/JsonModel-Swift.git",
         "state": {
           "branch": null,
-          "revision": "ddde0196c6e85b9adcfc3c5436b31b26f033f386",
-          "version": "1.4.7"
+          "revision": "cf13a8af6b09c25605f340150bb6392ea9d3c0f8",
+          "version": "2.0.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Sage-Bionetworks/MobilePassiveData-SDK.git",
         "state": {
           "branch": null,
-          "revision": "9c48602422ff2de9404112b9f2ed98c0a9ca2c44",
-          "version": "1.2.4"
+          "revision": "5c1b98eedde37fd6a898798c031f5e7d863404b3",
+          "version": "1.4.0"
         }
       },
       {


### PR DESCRIPTION
This allows this library to build against both JsonModel 1.6.0 (where the results are in the same target as the polymorphic serialization code) and JsonModel 2.0.0 (there the result model is pulled out into a separate target within the same repo).