### PR TITLE
Allow using the pause menu without requiring an assessment state

### DIFF
--- a/SwiftPackage/Sources/AssessmentModelUI/Views/AssessmentView.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/Views/AssessmentView.swift
@@ -150,7 +150,7 @@ public struct AssessmentWrapperView<StepContent : StepFactoryView> : View {
                 ProgressView()
             }
             TopBarProgressView()
-            PauseMenu(viewModel: viewModel)
+            PauseMenu(viewModel: viewModel, interruptionHandling: assessmentState.interruptionHandling)
                 .opacity(assessmentState.showingPauseActions ? 1 : 0)
                 .animation(.easeInOut, value: assessmentState.showingPauseActions)
         }

--- a/SwiftPackage/Sources/AssessmentModelUI/Views/Components/ExitButton.swift
+++ b/SwiftPackage/Sources/AssessmentModelUI/Views/Components/ExitButton.swift
@@ -6,6 +6,21 @@
 import SwiftUI
 import SharedMobileUI
 
+/// A button that shows a pause menu
+public struct PauseButton: View {
+    @Binding var showingPauseActions: Bool
+    
+    public init(_ showingPauseActions: Binding<Bool>) {
+        self._showingPauseActions = showingPauseActions
+    }
+    
+    public var body: some View {
+        Button(action: { showingPauseActions = true }) {
+            Image("pause", bundle: .module)
+        }
+    }
+}
+
 struct ExitButton: View {
     @EnvironmentObject var assessmentState: AssessmentState
     let canPause: Bool
@@ -18,9 +33,7 @@ struct ExitButton: View {
     @ViewBuilder
     func exitButton() -> some View {
         if canPause {
-            Button(action: { assessmentState.showingPauseActions = true }) {
-                Image("pause", bundle: .module)
-            }
+            PauseButton($assessmentState.showingPauseActions)
         }
         else {
             Button(action: { assessmentState.status = .continueLater }) {


### PR DESCRIPTION
This refactor is to allow @dephillipsmichael to use the same pause menu without having to wrap DIAN assessments in an assessment model.